### PR TITLE
Read commands phase

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -237,7 +237,7 @@ type command struct {
 	newOID  string
 }
 
-var validReferenceName = regexp.MustCompile(`^([0-9a-f]{64}) ([0-9a-f]{64}) (.+)`)
+var validReferenceName = regexp.MustCompile(`^([0-9a-f]{40,64}) ([0-9a-f]{40,64}) (.+)`)
 
 // readCommands reads the set of ref update commands sent by the client side.
 func (r *SpokesReceivePack) readCommands(_ context.Context) ([]command, []string, error) {


### PR DESCRIPTION
At this stage, the clients know what references the server is at, so it can send a list of reference updates

 For each reference on the server that it wants to update, it sends a line listing the object id currently on the server, the object id the client would like to update it to and the name of the reference

More details can be found in the [protocol description](https://github.com/github/git/blob/github/Documentation/technical/pack-protocol.txt)