### PR TITLE
Read packets phase

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -333,14 +333,15 @@ func (r *SpokesReceivePack) readPacket() ([]byte, error) {
 //
 // If GIT_SOCKSTAT_VAR_quarantine_dir is not specified, the pack will be written to objects/pack/ directory within the
 // current Git repository with a  default name determined from the pack content
-func (r *SpokesReceivePack) readPack(_ context.Context, commands []command) error {
+func (r *SpokesReceivePack) readPack(ctx context.Context, commands []command) error {
 	// We only get a pack if there are non-deletes.
 	if !includeNonDeletes(commands) {
 		return nil
 	}
 
 	// Index-pack will read directly from our input!
-	cmd := exec.Command(
+	cmd := exec.CommandContext(
+		ctx,
 		"git",
 		"index-pack",
 		"--fix-thin",


### PR DESCRIPTION
This pull implements the reading of the packets sent by the client.

The name generation of the resulting pack file could potentially conflict if two pushes come through at the very same nanosecond within the same `quarantine_dir`, but I don't know if this is even possible (not sure if every push has a different `quarantine_dir` or it will be the same for all the pushes in a particular repo)

```go
if quarantine := os.Getenv("GIT_SOCKSTAT_VAR_quarantine_dir"); quarantine != "" {
if err := os.Mkdir(quarantine, 0700); err != nil {
	return err
}
file := fmt.Sprintf("quarantine-%d.pack", time.Now().UnixNano())
cmd.Args = append(cmd.Args, filepath.Join(quarantine, file))
}
```