### PR TITLE
Check connectivity phase

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -467,8 +467,9 @@ func (r *SpokesReceivePack) performCheckConnectivity(ctx context.Context, comman
 	return nil
 }
 
-func (r *SpokesReceivePack) performCheckConnectivityOnObject(_ context.Context, oid string) error {
-	cmd := exec.Command(
+func (r *SpokesReceivePack) performCheckConnectivityOnObject(ctx context.Context, oid string) error {
+	cmd := exec.CommandContext(
+		ctx,
 		"git",
 		"rev-list",
 		"--objects",


### PR DESCRIPTION
At this point, we have properly processed the pack files sent by the client and we are ready to check the connectivity of the new oids the client has sent us.

We rely on `git rev-list` and pass through the stdin all the new oids the client has sent us in the previous commands. If we find a failure in any of the new oids, we double-check one by one which one were the ones that failed