### PR TITLE
Set up dependabot for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   allow:
     # Allow updates for GitHub-owned actions
     - dependency-name: "actions/*"
     - dependency-name: "github/*"
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,12 +3,6 @@ name: go test
 on:
   push:
 
-env:
-  GOPROXY: https://goproxy.githubapp.com/mod,https://proxy.golang.org,direct
-  GOPRIVATE: ''
-  GONOPROXY: ''
-  GONOSUMDB: github.com/github/*
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,9 +12,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19"
-      - name: Authenticate with goproxy.
-        run: |
-          echo "machine goproxy.githubapp.com login nobody password ${{ secrets.GOPROXY_TOKEN }}" >> $HOME/.netrc
       - name: Vendor modules for later steps.
         run: |
           go mod vendor

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,12 +3,6 @@ name: golangci-lint
 on:
   push:
 
-env:
-  GOPROXY: https://goproxy.githubapp.com/mod,https://proxy.golang.org,direct
-  GOPRIVATE: ''
-  GONOPROXY: ''
-  GONOSUMDB: github.com/github/*
-
 jobs:
   golangci:
     runs-on: ubuntu-latest
@@ -18,9 +12,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19"
-      - name: Authenticate with goproxy.
-        run: |
-          echo "machine goproxy.githubapp.com login nobody password ${{ secrets.CONTAINER_BUILDER_TOKEN }}" >> $HOME/.netrc
       - name: Vendor modules for later steps.
         run: |
           go mod vendor


### PR DESCRIPTION
I was looking at settings today and saw that Dependabot wasn't set up to update Go dependencies. This branch adds config for that.