### PR TITLE
check for correct sockstat variable

### DIFF
--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -21,7 +21,7 @@ func main() {
 
 func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
 	ctx := context.Background()
-	if os.Getenv(GitSockstatVarSpokesQuarantine) != "true" {
+	if os.Getenv(GitSockstatVarSpokesQuarantine) != "bool:true" {
 		rp := receivepack.NewReceivePack(stdin, stdout, stderr, args)
 		if err := rp.Execute(ctx); err != nil {
 			return fmt.Errorf("unexpected error running receive pack: %w", err)


### PR DESCRIPTION
Sockstat variables are prefixed with their type, so the actual environment variable will have the value "bool:true", not just "true".  Fix that.

/cc @github/git-access 