### PR TITLE
Only send back the report if the client has specified the corresponding capability

### DIFF
--- a/internal/pktline/capabilities.go
+++ b/internal/pktline/capabilities.go
@@ -175,3 +175,8 @@ func (c Capabilities) Get(cap string) (Capability, bool) {
 	capability, found := c.caps[cap]
 	return capability, found
 }
+
+func (c Capabilities) IsDefined(cap string) bool {
+	_, found := c.caps[cap]
+	return found
+}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -116,8 +116,10 @@ func (r *SpokesReceivePack) Execute(ctx context.Context) error {
 		}
 	}
 
-	if err := r.report(ctx, unpackErr == nil, commands); err != nil {
-		return err
+	if capabilities.IsDefined(pktline.ReportStatus) {
+		if err := r.report(ctx, unpackErr == nil, commands); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Right now, we are always sending back the status report, but we only should do it if the client has sent the corresponding capability