### PR TITLE
Report the atomic capability

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	capabilities = "report-status delete-refs side-band-64k ofs-delta"
+	capabilities = "report-status delete-refs side-band-64k ofs-delta atomic"
 	// maximum length of a pkt-line's data component
 	maxPacketDataLength = 65516
 	nullSHA1OID         = "0000000000000000000000000000000000000000"


### PR DESCRIPTION
Spokes-receive-pack doesn't need to implement this since this is something we take care of in our _commit_refs phase
