### PR TITLE
Announce object-format and agent capabilities

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	capabilities = "report-status delete-refs side-band-64k ofs-delta atomic"
+	capabilities = "report-status delete-refs side-band-64k ofs-delta atomic object-format=sha1"
 	// maximum length of a pkt-line's data component
 	maxPacketDataLength = 65516
 	nullSHA1OID         = "0000000000000000000000000000000000000000"

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -33,13 +33,14 @@ type SpokesReceivePack struct {
 	input         io.Reader
 	output        io.Writer
 	err           io.Writer
+	capabilities  string
 	repoPath      string
 	statelessRPC  bool
 	advertiseRefs bool
 }
 
 // NewSpokesReceivePack returns a pointer to a SpokesReceivePack executor
-func NewSpokesReceivePack(input io.Reader, output, err io.Writer, args []string) (*SpokesReceivePack, error) {
+func NewSpokesReceivePack(input io.Reader, output, err io.Writer, args []string, version string) (*SpokesReceivePack, error) {
 	statelessRPC := flag.Bool("stateless-rpc", false, "Indicates we are using the HTTP protocol")
 	httpBackendInfoRefs := flag.Bool("http-backend-info-refs", false, "Indicates we only need to announce the references")
 	flag.BoolVar(httpBackendInfoRefs, "advertise-refs", *httpBackendInfoRefs, "alias of --http-backend-info-refs")
@@ -54,6 +55,7 @@ func NewSpokesReceivePack(input io.Reader, output, err io.Writer, args []string)
 		input:         input,
 		output:        output,
 		err:           err,
+		capabilities:  capabilities + fmt.Sprintf(" agent=github/spokes-receive-pack-%s", version),
 		repoPath:      repoPath,
 		statelessRPC:  *statelessRPC,
 		advertiseRefs: *httpBackendInfoRefs,
@@ -190,7 +192,7 @@ func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 	}
 
 	if len(references) > 0 {
-		if err := writePacketf(r.output, "%s\x00%s\n", references[0], capabilities); err != nil {
+		if err := writePacketf(r.output, "%s\x00%s\n", references[0], r.capabilities); err != nil {
 			return fmt.Errorf("writing capability packet: %w", err)
 		}
 
@@ -200,7 +202,7 @@ func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 			}
 		}
 	} else {
-		if err := writePacketf(r.output, "%s capabilities^{}\x00%s", nullSHA1OID, capabilities); err != nil {
+		if err := writePacketf(r.output, "%s capabilities^{}\x00%s", nullSHA1OID, r.capabilities); err != nil {
 			return fmt.Errorf("writing lonely capability packet: %w", err)
 		}
 	}

--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -12,6 +12,8 @@ import (
 
 const GitSockstatVarSpokesQuarantine = "GIT_SOCKSTAT_VAR_spokes_quarantine"
 
+var BuildVersion string
+
 func main() {
 	if err := mainImpl(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -27,7 +29,7 @@ func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
 			return fmt.Errorf("unexpected error running receive pack: %w", err)
 		}
 	} else {
-		rp, err := spokes.NewSpokesReceivePack(stdin, stdout, stderr, args)
+		rp, err := spokes.NewSpokesReceivePack(stdin, stdout, stderr, args, BuildVersion)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Announce these two capabilities (in the spec they are marked as optional). The `agent` could be useful in future debugging processes.

This pull is built on top of #18, so should be merged after that
