### PR TITLE
Announce the push-options capability

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	capabilities = "report-status delete-refs side-band-64k ofs-delta atomic object-format=sha1"
+	capabilities = "report-status delete-refs side-band-64k ofs-delta atomic push-options object-format=sha1"
 	// maximum length of a pkt-line's data component
 	maxPacketDataLength = 65516
 	nullSHA1OID         = "0000000000000000000000000000000000000000"


### PR DESCRIPTION
The options sent by the `--push-option` flag are passed through to the pre and post receive hooks by the default git-receive-pack implementation. However, our current spokes-receive-pack impl doesn't invoke any hook, so we should be okay just announcing the capability but not performing the actual parsing
