### PR TITLE
Babeld integration fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-integration: BUILDTAGS=-tags integration
 test-integration: all go-binaries go-test-integration
 
 TESTFLAGS := -race
-TESTINTEGRATIONFLAGS := $(TESTFLAGS) --tags=integration
+TESTINTEGRATIONFLAGS := $(TESTFLAGS) --tags=integration --count=1
 TESTSUITE := ./...
 .PHONY: go-test
 go-test:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-integration: BUILDTAGS=-tags integration
 test-integration: all go-binaries go-test-integration
 
 TESTFLAGS := -race
-TESTINTEGRATIONFLAGS := $(TESTFLAGS) --tags=integration --count=1
+TESTINTEGRATIONFLAGS := $(TESTFLAGS) --tags=integration
 TESTSUITE := ./...
 .PHONY: go-test
 go-test:

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -99,7 +99,7 @@ func (suite *SpokesReceivePackTestSuite) TestDefaultReceivePackSimplePush() {
 	assert.NoError(
 		suite.T(),
 		exec.Command(
-			"git", "push", "--receive-pack=spokes-receive-pack", "r", "master").Run(),
+			"git", "push", "--receive-pack=spokes-receive-pack", "r", "HEAD").Run(),
 		"unexpected error running the push with the default receive-pack implementation")
 }
 
@@ -108,7 +108,7 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackSimplePush() {
 	assert.NoError(
 		suite.T(),
 		exec.Command(
-			"git", "push", "--receive-pack=spokes-receive-pack-wrapper", "r", "master").Run(),
+			"git", "push", "--receive-pack=spokes-receive-pack-wrapper", "r", "HEAD").Run(),
 		"unexpected error running the push with the custom spokes-receive-pack program")
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -27,7 +27,7 @@ This commit object intentionally broken
 
 type SpokesReceivePackTestSuite struct {
 	suite.Suite
-	localRepo, remoteRepo string
+	localRepo, remoteRepo, shallowClone string
 }
 
 func (suite *SpokesReceivePackTestSuite) SetupTest() {
@@ -74,9 +74,15 @@ func (suite *SpokesReceivePackTestSuite) SetupTest() {
 
 	req.NoError(exec.Command("git", "init", "--quiet", "--template=.", "--bare").Run())
 
+	// create a clone of our local repo with --depth=1
+	shallowClone, err := os.MkdirTemp("", "shallow-clone")
+	req.NoError(err, "unable to create the shallow-clone repository directory")
+	req.NoError(exec.Command("git", "clone", "--depth=1", fmt.Sprintf("file://%s", localRepo), shallowClone).Run())
+
 	// store the state
 	suite.localRepo = localRepo
 	suite.remoteRepo = remoteRepo
+	suite.shallowClone = shallowClone
 }
 
 func (suite *SpokesReceivePackTestSuite) TearDownTest() {
@@ -85,6 +91,7 @@ func (suite *SpokesReceivePackTestSuite) TearDownTest() {
 	// Clean the environment before exiting
 	require.NoError(os.RemoveAll(suite.remoteRepo))
 	require.NoError(os.RemoveAll(suite.localRepo))
+	require.NoError(os.RemoveAll(suite.shallowClone))
 }
 
 func (suite *SpokesReceivePackTestSuite) TestDefaultReceivePackSimplePush() {
@@ -198,6 +205,17 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackWrongObjectSucceed
 			err,
 			"unexpected error running the push with the custom spokes-receive-pack program; it should have succeed since fsck is disabled")
 	})
+}
+
+func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackPushFromShallowClone() {
+	assert.NoError(suite.T(), os.Chdir(suite.shallowClone), "unable to chdir into our local shallow clone")
+
+	out, err := exec.Command(
+		"git", "push", "--receive-pack=spokes-receive-pack-wrapper", "origin", "HEAD:test").CombinedOutput()
+
+	suite.T().Logf("ERROR:%s", out)
+	require.NoError(suite.T(), err)
+
 }
 
 func createBogusObjectAndPush(suite *SpokesReceivePackTestSuite, validations func(*SpokesReceivePackTestSuite, error, []byte)) {

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -379,7 +379,6 @@ func (r *SpokesReceivePack) readCommands(_ context.Context) ([]command, []string
 		}
 
 		// Parse the shallow "commands" the client could have sent
-
 		payload := string(pl.Payload)
 		if strings.HasPrefix(payload, "shallow") {
 			payloadParts := strings.Split(payload, " ")

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -474,13 +474,15 @@ func (r *SpokesReceivePack) readPack(ctx context.Context, commands []command, ca
 	if quarantine := os.Getenv("GIT_SOCKSTAT_VAR_quarantine_dir"); quarantine != "" {
 		quarantineDir = quarantine
 		quarantinePackDir = fmt.Sprintf("%s/pack", quarantine)
+		if err := os.MkdirAll(quarantinePackDir, 0700); err != nil {
+			return err
+		}
 	} else {
-		quarantineDir = fmt.Sprintf("%s-%d", "default-quarantine", time.Now().UnixNano())
+		quarantineDir, err = os.MkdirTemp(".", "default-quarantine")
+		if err != nil {
+			return err
+		}
 		quarantinePackDir = fmt.Sprintf("%s/pack", quarantineDir)
-	}
-
-	if err := os.MkdirAll(quarantinePackDir, 0700); err != nil {
-		return err
 	}
 
 	cmd.Args = append(

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -117,24 +117,25 @@ func (r *SpokesReceivePack) Execute(ctx context.Context) error {
 		// * If no individual error has been found and the reportStatusFF settings is true, let's see if the reference update could be a fast-forward
 		for i := range commands {
 			c := &commands[i]
-			if !c.rejected {
-				var singleObjectErr error
-				c.reportFF = "ok"
-				if err != nil {
-					singleObjectErr = r.performCheckConnectivityOnObject(ctx, c.newOID)
-					if singleObjectErr != nil {
-						c.err = fmt.Sprintf("missing required objects: %s", err.Error())
-						c.reportFF = "ng"
-					}
+			if c.rejected {
+				continue
+			}
+			var singleObjectErr error
+			c.reportFF = "ok"
+			if err != nil {
+				singleObjectErr = r.performCheckConnectivityOnObject(ctx, c.newOID)
+				if singleObjectErr != nil {
+					c.err = fmt.Sprintf("missing required objects: %s", err.Error())
+					c.reportFF = "ng"
 				}
+			}
 
-				if singleObjectErr == nil && c.isUpdate() && r.isReportStatusFFConfigEnabled() {
-					// check if a fast-forward could be performed
-					if isFastForward(c, ctx) {
-						c.reportFF = "ff"
-					} else {
-						c.reportFF = "nf"
-					}
+			if singleObjectErr == nil && c.isUpdate() && r.isReportStatusFFConfigEnabled() {
+				// check if a fast-forward could be performed
+				if isFastForward(c, ctx) {
+					c.reportFF = "ff"
+				} else {
+					c.reportFF = "nf"
 				}
 			}
 		}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -103,7 +103,7 @@ func (r *SpokesReceivePack) Execute(ctx context.Context) error {
 	// Now that we have all the commands sent by the client side, we are ready to process them and read the
 	// corresponding packfiles
 	var unpackErr error
-	if unpackErr := r.readPack(ctx, commands, capabilities); unpackErr != nil {
+	if unpackErr = r.readPack(ctx, commands, capabilities); unpackErr != nil {
 		for i := range commands {
 			commands[i].err = fmt.Sprintf("error processing packfiles: %s", unpackErr.Error())
 			commands[i].reportFF = "ng"

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -116,23 +116,25 @@ func (r *SpokesReceivePack) Execute(ctx context.Context) error {
 		// * If we found a general check-connectivity error, let's check every individual command
 		// * If no individual error has been found and the reportStatusFF settings is true, let's see if the reference update could be a fast-forward
 		for i := range commands {
-			var singleObjectErr error
 			c := &commands[i]
-			c.reportFF = "ok"
-			if err != nil {
-				singleObjectErr = r.performCheckConnectivityOnObject(ctx, c.newOID)
-				if singleObjectErr != nil {
-					c.err = fmt.Sprintf("missing required objects: %s", err.Error())
-					c.reportFF = "ng"
+			if !c.rejected {
+				var singleObjectErr error
+				c.reportFF = "ok"
+				if err != nil {
+					singleObjectErr = r.performCheckConnectivityOnObject(ctx, c.newOID)
+					if singleObjectErr != nil {
+						c.err = fmt.Sprintf("missing required objects: %s", err.Error())
+						c.reportFF = "ng"
+					}
 				}
-			}
 
-			if singleObjectErr == nil && c.isUpdate() && r.isReportStatusFFConfigEnabled() {
-				// check if a fast-forward could be performed
-				if isFastForward(c, ctx) {
-					c.reportFF = "ff"
-				} else {
-					c.reportFF = "nf"
+				if singleObjectErr == nil && c.isUpdate() && r.isReportStatusFFConfigEnabled() {
+					// check if a fast-forward could be performed
+					if isFastForward(c, ctx) {
+						c.reportFF = "ff"
+					} else {
+						c.reportFF = "nf"
+					}
 				}
 			}
 		}
@@ -168,7 +170,7 @@ func isFastForward(c *command, ctx context.Context) bool {
 // It writes back to the client the capability listing and a packet-line for every reference
 // terminated with a flush-pkt
 func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error {
-	config, err := config.GetConfig(r.repoPath, "receive.hiderefs")
+	hiddenRefs, err := r.getHiddenRefs()
 	if err != nil {
 		return err
 	}
@@ -181,7 +183,7 @@ func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 			"collect-references",
 			func(ctx context.Context, _ pipe.Env, line []byte, stdout *bufio.Writer) error {
 				// Ignore the current line if it is a hidden ref
-				if !isHiddenRef(line, config.Entries) {
+				if !isHiddenRef(string(line), hiddenRefs) {
 					references = append(references, line)
 				}
 
@@ -213,7 +215,7 @@ func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 					"collect-alternates-references",
 					func(ctx context.Context, _ pipe.Env, line []byte, stdout *bufio.Writer) error {
 						// Ignore the current line if it is a hidden ref
-						if !isHiddenRef(line, config.Entries) {
+						if !isHiddenRef(string(line), hiddenRefs) {
 							references = append(references, line)
 						}
 
@@ -251,6 +253,18 @@ func (r *SpokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 	return nil
 }
 
+func (r *SpokesReceivePack) getHiddenRefs() ([]string, error) {
+	config, err := config.GetConfig(r.repoPath, "receive.hiderefs")
+	if err != nil {
+		return nil, err
+	}
+	var hiddenRefs []string
+	for _, hr := range config.Entries {
+		hiddenRefs = append(hiddenRefs, hr.Value)
+	}
+	return hiddenRefs, nil
+}
+
 func (r *SpokesReceivePack) networkRepoPath() (string, error) {
 	alternatesPath := filepath.Join(r.repoPath, "objects", "info", "alternates")
 	alternatesBytes, err := os.ReadFile(alternatesPath)
@@ -285,10 +299,9 @@ func (r *SpokesReceivePack) networkRepoPath() (string, error) {
 // isHiddenRef determines if the line passed as the first argument belongs to the list of
 // potential references that we don't want to advertise
 // This method assumes the config entries passed as a second argument are the ones in the `receive.hiderefs` section
-func isHiddenRef(line []byte, entries []config.ConfigEntry) bool {
-	l := string(line)
-	for _, entry := range entries {
-		if strings.Contains(l, entry.Value) {
+func isHiddenRef(line string, hiddenRefs []string) bool {
+	for _, hr := range hiddenRefs {
+		if strings.Contains(line, hr) {
 			return true
 		}
 	}
@@ -332,6 +345,7 @@ type command struct {
 	newOID   string
 	err      string
 	reportFF string
+	rejected bool
 }
 
 func (c *command) isUpdate() bool {
@@ -348,6 +362,11 @@ func (r *SpokesReceivePack) readCommands(_ context.Context) ([]command, []string
 	first := true
 	pl := pktline.New()
 	var capabilities pktline.Capabilities
+
+	hiddenRefs, err := r.getHiddenRefs()
+	if err != nil {
+		return []command{}, nil, capabilities, err
+	}
 
 	for {
 		err := pl.Read(r.input)
@@ -379,15 +398,19 @@ func (r *SpokesReceivePack) readCommands(_ context.Context) ([]command, []string
 			first = false
 		}
 
-		if m := validReferenceName.FindStringSubmatch(string(pl.Payload)); m != nil {
-			commands = append(
-				commands,
-				command{
-					oldOID:  m[1],
-					newOID:  m[2],
-					refname: m[3],
-				},
-			)
+		if m := validReferenceName.FindStringSubmatch(payload); m != nil {
+			c := command{
+				oldOID:  m[1],
+				newOID:  m[2],
+				refname: m[3],
+			}
+			if isHiddenRef(c.refname, hiddenRefs) {
+				c.reportFF = "ng"
+				c.err = "deny updating a hidden ref"
+				c.rejected = true
+			}
+
+			commands = append(commands, c)
 			continue
 		}
 
@@ -606,6 +629,13 @@ func (r *SpokesReceivePack) getAlternateObjectDirsEnv() []string {
 // closed under reachability, stopping the traversal at any objects
 // reachable from the pre-existing reference values.
 func (r *SpokesReceivePack) performCheckConnectivity(ctx context.Context, commands []command) error {
+	nonRejectedCommands := filterNonRejectedCommands(commands)
+	if len(nonRejectedCommands) == 0 {
+		// all the commands have been previously rejected so there is no need to perform
+		// a connectivity check
+		return nil
+	}
+
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", os.DevNull, err)
@@ -655,10 +685,20 @@ func (r *SpokesReceivePack) performCheckConnectivity(ctx context.Context, comman
 	)
 
 	if err := p.Run(ctx); err != nil {
-		return fmt.Errorf("running 'rev-list': %w", err)
+		return fmt.Errorf("performCheckConnectivity error: %w", err)
 	}
 
 	return nil
+}
+
+func filterNonRejectedCommands(commands []command) []command {
+	var nonRejectedCommands []command
+	for _, c := range commands {
+		if !c.rejected {
+			nonRejectedCommands = append(nonRejectedCommands, c)
+		}
+	}
+	return nonRejectedCommands
 }
 
 func (r *SpokesReceivePack) performCheckConnectivityOnObject(ctx context.Context, oid string) error {

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -117,7 +117,7 @@ func (r *SpokesReceivePack) Execute(ctx context.Context) error {
 		// * If no individual error has been found and the reportStatusFF settings is true, let's see if the reference update could be a fast-forward
 		for i := range commands {
 			c := &commands[i]
-			if c.rejected {
+			if c.err != "" {
 				continue
 			}
 			var singleObjectErr error
@@ -346,7 +346,6 @@ type command struct {
 	newOID   string
 	err      string
 	reportFF string
-	rejected bool
 }
 
 func (c *command) isUpdate() bool {
@@ -407,7 +406,6 @@ func (r *SpokesReceivePack) readCommands(_ context.Context) ([]command, []string
 			if isHiddenRef(c.refname, hiddenRefs) {
 				c.reportFF = "ng"
 				c.err = "deny updating a hidden ref"
-				c.rejected = true
 			}
 
 			commands = append(commands, c)
@@ -694,7 +692,7 @@ func (r *SpokesReceivePack) performCheckConnectivity(ctx context.Context, comman
 func filterNonRejectedCommands(commands []command) []command {
 	var nonRejectedCommands []command
 	for _, c := range commands {
-		if !c.rejected {
+		if c.err != "" {
 			nonRejectedCommands = append(nonRejectedCommands, c)
 		}
 	}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -715,8 +715,9 @@ func (r *SpokesReceivePack) performCheckConnectivityOnObject(ctx context.Context
 	)
 	cmd.Env = append(cmd.Env, r.getAlternateObjectDirsEnv()...)
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("running 'rev-list' on oid %s: %s", oid, err)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("performCheckConnectivityOnObject on oid %s: %s. Details: %s", oid, err, string(out))
 	}
 
 	return nil

--- a/internal/spokes/spokes_test.go
+++ b/internal/spokes/spokes_test.go
@@ -2,46 +2,33 @@ package spokes
 
 import (
 	"fmt"
-	"github.com/github/spokes-receive-pack/internal/config"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckHiddenRefs(t *testing.T) {
-	hiddenRefs := []config.ConfigEntry{
-		{
-			Key:   "receive.hiderefs",
-			Value: "refs/pull/",
-		},
-		{
-			Key:   "receive.hiderefs",
-			Value: "refs/gh/",
-		},
-		{
-			Key:   "receive.hiderefs",
-			Value: "refs/__gh__",
-		},
-	}
+	hiddenRefs := []string{"refs/pull/", "refs/gh/", "refs/__gh__"}
 	for _, p := range []struct {
-		line       []byte
-		hiddenRefs []config.ConfigEntry
+		line       string
+		hiddenRefs []string
 		expected   bool
 	}{
-		{[]byte("886459bb202402741948881fe9e99554ba264cac refs/heads/add-testify-framework"), hiddenRefs, false},
-		{[]byte("602bc9cb256c46fcf9c3351864431448096f8538 refs/heads/advertise-capabilities"), hiddenRefs, false},
-		{[]byte("4fff972d2c997e98d80039551162d4cb51111760 refs/heads/initial-version"), hiddenRefs, false},
-		{[]byte("b01cd23d0137c518529ab21e0d138291bd481980 refs/heads/introduce-custom-mode"), hiddenRefs, false},
-		{[]byte("28e3c79ae2b2798e7468d6eeb8601408a613cbcd refs/heads/main"), hiddenRefs, false},
-		{[]byte("b7841935938c6c73666e050d73e7bc8e9a547f70 refs/heads/read-commands-phase"), hiddenRefs, false},
-		{[]byte("65b64fe7f4419e4ffaa988fa7ac9801baf790034 refs/remotes/origin/HEAD"), hiddenRefs, false},
-		{[]byte("886459bb202402741948881fe9e99554ba264cac refs/remotes/origin/add-testify-framework"), hiddenRefs, false},
-		{[]byte("e1adb492bcee63e359e30c82237b868347323f67 refs/remotes/origin/advertise-capabilities"), hiddenRefs, false},
-		{[]byte("4fff972d2c997e98d80039551162d4cb51111760 refs/remotes/origin/initial-version"), hiddenRefs, false},
-		{[]byte("b01cd23d0137c518529ab21e0d138291bd481980 refs/remotes/origin/introduce-custom-mode"), hiddenRefs, false},
-		{[]byte("65b64fe7f4419e4ffaa988fa7ac9801baf790034 refs/remotes/origin/main"), hiddenRefs, false},
-		{[]byte("93dc373b5dd6f280e57ada1ca2b41aa7dba52f89 refs/__gh__/pull/99986/rebase"), hiddenRefs, true},
-		{[]byte("99681cf8b50d6c0616f10e67d7bb9f3589ca6a8d refs/gh/merge_queue/156066/6e33e3a2c52017bec941ffd6f15c20a1ae002ad9"), hiddenRefs, true},
-		{[]byte("dc3d88418f0e0ad43842f5645b9a36db55187a40 refs/pull/95628/head"), hiddenRefs, true},
+		{"886459bb202402741948881fe9e99554ba264cac refs/heads/add-testify-framework", hiddenRefs, false},
+		{"602bc9cb256c46fcf9c3351864431448096f8538 refs/heads/advertise-capabilities", hiddenRefs, false},
+		{"4fff972d2c997e98d80039551162d4cb51111760 refs/heads/initial-version", hiddenRefs, false},
+		{"b01cd23d0137c518529ab21e0d138291bd481980 refs/heads/introduce-custom-mode", hiddenRefs, false},
+		{"28e3c79ae2b2798e7468d6eeb8601408a613cbcd refs/heads/main", hiddenRefs, false},
+		{"b7841935938c6c73666e050d73e7bc8e9a547f70 refs/heads/read-commands-phase", hiddenRefs, false},
+		{"65b64fe7f4419e4ffaa988fa7ac9801baf790034 refs/remotes/origin/HEAD", hiddenRefs, false},
+		{"886459bb202402741948881fe9e99554ba264cac refs/remotes/origin/add-testify-framework", hiddenRefs, false},
+		{"e1adb492bcee63e359e30c82237b868347323f67 refs/remotes/origin/advertise-capabilities", hiddenRefs, false},
+		{"4fff972d2c997e98d80039551162d4cb51111760 refs/remotes/origin/initial-version", hiddenRefs, false},
+		{"b01cd23d0137c518529ab21e0d138291bd481980 refs/remotes/origin/introduce-custom-mode", hiddenRefs, false},
+		{"65b64fe7f4419e4ffaa988fa7ac9801baf790034 refs/remotes/origin/main", hiddenRefs, false},
+		{"93dc373b5dd6f280e57ada1ca2b41aa7dba52f89 refs/__gh__/pull/99986/rebase", hiddenRefs, true},
+		{"99681cf8b50d6c0616f10e67d7bb9f3589ca6a8d refs/gh/merge_queue/156066/6e33e3a2c52017bec941ffd6f15c20a1ae002ad9", hiddenRefs, true},
+		{"dc3d88418f0e0ad43842f5645b9a36db55187a40 refs/pull/95628/head", hiddenRefs, true},
 	} {
 		t.Run(
 			fmt.Sprintf("TestCheckHiddenRefs(%q, %q)", p.line, p.hiddenRefs),


### PR DESCRIPTION
This pull tries to solve a few problems that have been discovered while trying to integrate `babeld` and `spokes-receive-pack`

## Read the shallow info

`spokes-receive-pack` didn't read the potential `shallow pkt-lines` sent over the wire. This pull is just processing them, so we don't break the protocol, but, for now, they are not being used.

## Quarantine folder

This pull request provides a more robust approach when we handle the quarantine folder, and we handle the potential scenario where the corresponding sockstat variable is not defined

## Better handling of the hidden refs

We have slightly improved the way we handle the hidden refs, and try to make sure that we don't perform any validation when we have no references to deal with.


I will continue taking a look at more integration errors, but I thought these changes were already ready for a broader review. I have included all of them in this pull, but if you prefer a separate one for every one of them just let me know and I will open the corresponding pull for every major change