### PR TITLE
Add support for the ! modifier when dealing with the hidden refs config section

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -311,11 +311,20 @@ func (r *SpokesReceivePack) networkRepoPath() (string, error) {
 // This method assumes the config entries passed as a second argument are the ones in the `receive.hiderefs` section
 func isHiddenRef(ref string, hiddenRefs []string) bool {
 	for _, hr := range hiddenRefs {
-		if strings.HasPrefix(ref, hr) {
+		neg, strippedRef := isNegativeRef(hr)
+
+		if strings.HasPrefix(ref, strippedRef) && !neg {
 			return true
 		}
 	}
 	return false
+}
+
+func isNegativeRef(ref string) (bool, string) {
+	if strings.HasPrefix(ref, "!") {
+		return true, ref[1:]
+	}
+	return false, ref
 }
 
 // writePacket writes `data` to the `r.output` as a pkt-line.

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -310,14 +310,20 @@ func (r *SpokesReceivePack) networkRepoPath() (string, error) {
 // potential references that we don't want to advertise
 // This method assumes the config entries passed as a second argument are the ones in the `receive.hiderefs` section
 func isHiddenRef(ref string, hiddenRefs []string) bool {
+	isHidden := false
 	for _, hr := range hiddenRefs {
 		neg, strippedRef := isNegativeRef(hr)
 
-		if strings.HasPrefix(ref, strippedRef) && !neg {
-			return true
+		if strings.HasPrefix(ref, strippedRef) {
+			if neg {
+				isHidden = false
+			} else {
+				isHidden = true
+			}
+
 		}
 	}
-	return false
+	return isHidden
 }
 
 func isNegativeRef(ref string) (bool, string) {

--- a/internal/spokes/spokes_test.go
+++ b/internal/spokes/spokes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCheckHiddenRefs(t *testing.T) {
-	hiddenRefs := []string{"refs/pull/", "refs/gh/", "refs/__gh__"}
+	hiddenRefs := []string{"refs/pull/", "refs/gh/", "refs/__gh__", "!refs/__github__/svn"}
 	for _, p := range []struct {
 		line       string
 		hiddenRefs []string
@@ -28,7 +28,7 @@ func TestCheckHiddenRefs(t *testing.T) {
 		{"refs/remotes/origin/main", hiddenRefs, false},
 		{"refs/__gh__/pull/99986/rebase", hiddenRefs, true},
 		{"refs/gh/merge_queue/156066/6e33e3a2c52017bec941ffd6f15c20a1ae002ad9", hiddenRefs, true},
-		{"refs/pull/95628/head", hiddenRefs, true},
+		{"refs/__github__/svn/branch-1", hiddenRefs, false},
 	} {
 		t.Run(
 			fmt.Sprintf("TestCheckHiddenRefs(%q, %q)", p.line, p.hiddenRefs),

--- a/internal/spokes/spokes_test.go
+++ b/internal/spokes/spokes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCheckHiddenRefs(t *testing.T) {
-	hiddenRefs := []string{"refs/pull/", "refs/gh/", "refs/__gh__", "!refs/__github__/svn"}
+	hiddenRefs := []string{"refs/pull/", "refs/gh/", "refs/__gh__", "!refs/__gh__/svn"}
 	for _, p := range []struct {
 		line       string
 		hiddenRefs []string
@@ -28,7 +28,8 @@ func TestCheckHiddenRefs(t *testing.T) {
 		{"refs/remotes/origin/main", hiddenRefs, false},
 		{"refs/__gh__/pull/99986/rebase", hiddenRefs, true},
 		{"refs/gh/merge_queue/156066/6e33e3a2c52017bec941ffd6f15c20a1ae002ad9", hiddenRefs, true},
-		{"refs/__github__/svn/branch-1", hiddenRefs, false},
+		{"refs/pull/95628/head", hiddenRefs, true},
+		{"refs/__gh__/svn/branch-1", hiddenRefs, false},
 	} {
 		t.Run(
 			fmt.Sprintf("TestCheckHiddenRefs(%q, %q)", p.line, p.hiddenRefs),


### PR DESCRIPTION
This PR adds support for the '!' modifier in the hidrefs config section.

I have not included the support for `^` in this pull request because, right now, `spokes-receive-pack` doesn't deal with namespaces. Should we add support for namespaces to `spokes-receive-pack`? 