### PR TITLE
Drop ops_slack

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -10,7 +10,6 @@ ownership:
   qos: experimental
   team: github/git-access
   team_slack: git-systems
-  ops_slack: git-systems-alerts
   maintainer: spraints
   exec_sponsor: prplr
   product_manager: vtbassmatt


### PR DESCRIPTION
It's deprecated and was set to the same value as sev3.slack, so wasn't
needed anyway.
