### PR TITLE
Report activity to governor

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -99,9 +99,23 @@ func (c *Conn) Finish(ctx context.Context) {
 		return
 	}
 
+	stats := getProcStats()
+	c.finish.CPU = stats.CPU
+	c.finish.RSS = stats.RSS
+	c.finish.DiskReadBytes = stats.DiskReadBytes
+	c.finish.DiskWriteBytes = stats.DiskWriteBytes
+
 	_ = finish(c.sock, c.finish)
+
 	c.sock.Close()
 	c.sock = nil
+}
+
+type procStats struct {
+	CPU            uint32
+	RSS            uint64
+	DiskReadBytes  uint64
+	DiskWriteBytes uint64
 }
 
 func connect(ctx context.Context) (net.Conn, error) {

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -22,7 +22,7 @@ const (
 //
 // If there is a connection or other low level error when talking to governor,
 // Start will return (nil, nil).
-func Start(ctx context.Context) (*Conn, error) {
+func Start(ctx context.Context, gitDir string) (*Conn, error) {
 	sock, err := connect(ctx)
 	if err != nil {
 		return nil, nil
@@ -31,7 +31,7 @@ func Start(ctx context.Context) (*Conn, error) {
 	updateData := readSockstat(os.Environ())
 	updateData.PID = os.Getpid()
 	updateData.Program = "spokes-receive-pack"
-	updateData.GitDir, _ = os.Getwd()
+	updateData.GitDir = gitDir
 	if err := update(sock, updateData); err != nil {
 		sock.Close()
 		return nil, nil

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -96,7 +96,7 @@ func connect(ctx context.Context) (net.Conn, error) {
 	defer cancel()
 
 	path := os.Getenv("GIT_SOCKSTAT_PATH")
-	if path != "" {
+	if path == "" {
 		path = "/var/run/gitmon/gitstats.sock"
 	}
 

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -78,6 +78,19 @@ func (c *Conn) SetError(exitCode uint8, message string) {
 	c.finish.Fatal = message
 }
 
+// SetReceivePackSize records the incoming packfile's size to include with the
+// finish message.
+//
+// It is safe to call SetReceivePackSize with a nil *Conn.
+func (c *Conn) SetReceivePackSize(size int64) {
+	if c == nil {
+		return
+	}
+	if size > 0 {
+		c.finish.ReceivePackSize = uint64(size)
+	}
+}
+
 // Finish sends the "finish" message to governor and closes the connection.
 //
 // It is safe to call Finish with a nil *Conn.

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -183,7 +183,7 @@ func readSockstat(environ []string) updateData {
 // uint32 like 123. If the prefix is missing or the value isn't a uint32,
 // return 0.
 func sockstatUint32(s string) uint32 {
-	s, ok := strings.CutPrefix(s, "uint:")
+	s, ok := cutPrefix(s, "uint:")
 	if !ok {
 		return 0
 	}
@@ -204,4 +204,12 @@ func sockstatString(s string) string {
 		return parts[1]
 	}
 	return s
+}
+
+// TODO: replace with Go 1.20's strings.CutPrefix
+func cutPrefix(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
 }

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -1,13 +1,161 @@
 package governor
 
-import "context"
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
 
-func Start(ctx context.Context) *Conn {
-	return nil
+const (
+	connectTimeout  = time.Second
+	scheduleTimeout = time.Second
+)
+
+// Start connects to governor and sends the "update" and "schedule" messages.
+//
+// If "schedule" says to wait, Start will pause for the specified time and try
+// calling "schedule" again.
+//
+// If there is a connection or other low level error when talking to governor,
+// Start will return (nil, nil).
+func Start(ctx context.Context) (*Conn, error) {
+	sock, err := connect(ctx)
+	if err != nil {
+		return nil, nil
+	}
+
+	updateData := readSockstat(os.Environ())
+	updateData.PID = os.Getpid()
+	updateData.Program = "spokes-receive-pack"
+	updateData.GitDir, _ = os.Getwd()
+	if err := update(sock, updateData); err != nil {
+		sock.Close()
+		return nil, nil
+	}
+
+	br := bufio.NewReader(sock)
+	for {
+		// Give governor 1s to respond each schedule call.
+		sock.SetReadDeadline(time.Now().Add(scheduleTimeout))
+		err := schedule(br, sock)
+		if err == nil {
+			break
+		}
+
+		switch e := err.(type) {
+		case WaitError:
+			time.Sleep(e.Duration)
+		case FailError:
+			sock.Close()
+			return nil, err
+		default:
+			sock.Close()
+			return nil, nil
+		}
+	}
+
+	return &Conn{sock: sock}, nil
 }
 
+// Conn is an active connection to governor.
 type Conn struct {
+	sock net.Conn
 }
 
+// Finish sends the "finish" message to governor and closes the connection.
+//
+// It is safe to call Finish with a nil *Conn.
 func (c *Conn) Finish(ctx context.Context) {
+}
+
+func connect(ctx context.Context) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
+	path := os.Getenv("GIT_SOCKSTAT_PATH")
+	if path != "" {
+		path = "/var/run/gitmon/gitstats.sock"
+	}
+
+	dialer := &net.Dialer{}
+	return dialer.DialContext(ctx, "unix", path)
+}
+
+func readSockstat(environ []string) updateData {
+	var res updateData
+
+	const prefix = "GIT_SOCKSTAT_VAR_"
+	for _, env := range environ {
+		if !strings.HasPrefix(env, prefix) {
+			continue
+		}
+		env = env[len(prefix):]
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		switch parts[0] {
+		case "repo_name":
+			res.RepoName = sockstatString(parts[1])
+		case "repo_id":
+			res.RepoID = sockstatUint32(parts[1])
+		case "network_id":
+			res.NetworkID = sockstatUint32(parts[1])
+		case "user_id":
+			res.UserID = sockstatUint32(parts[1])
+		case "real_ip":
+			res.RealIP = sockstatString(parts[1])
+		case "request_id":
+			res.RequestID = sockstatString(parts[1])
+		case "user_agent":
+			res.UserAgent = sockstatString(parts[1])
+		case "features":
+			res.Features = sockstatString(parts[1])
+		case "via":
+			res.Via = sockstatString(parts[1])
+		case "ssh_connection":
+			res.SSHConnection = sockstatString(parts[1])
+		case "babeld":
+			res.Babeld = sockstatString(parts[1])
+		case "git_protocol":
+			res.GitProtocol = sockstatString(parts[1])
+		case "pubkey_verifier_id":
+			res.PubkeyVerifierID = sockstatUint32(parts[1])
+		case "pubkey_creator_id":
+			res.PubkeyCreatorID = sockstatUint32(parts[1])
+		}
+	}
+
+	return res
+}
+
+// sockstatUint32 parses a string like "uint32:123" and returns the parsed
+// uint32 like 123. If the prefix is missing or the value isn't a uint32,
+// return 0.
+func sockstatUint32(s string) uint32 {
+	s, ok := strings.CutPrefix(s, "uint:")
+	if !ok {
+		return 0
+	}
+	val, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(val)
+}
+
+// sockstatString returns the string version of the given sockstat var. For the
+// most part, this means just returning the given string. However, if the input
+// has a uint or bool prefix, strip that off so that it looks like we parsed
+// the value and then stringified it.
+func sockstatString(s string) string {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) == 2 && (parts[0] == "uint" || parts[0] == "bool") {
+		return parts[1]
+	}
+	return s
 }

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -1,0 +1,13 @@
+package governor
+
+import "context"
+
+func Start(ctx context.Context) *Conn {
+	return nil
+}
+
+type Conn struct {
+}
+
+func (c *Conn) Finish(ctx context.Context) {
+}

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -40,7 +40,10 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 	br := bufio.NewReader(sock)
 	for {
 		// Give governor 1s to respond each schedule call.
-		sock.SetReadDeadline(time.Now().Add(scheduleTimeout))
+		if err := sock.SetReadDeadline(time.Now().Add(scheduleTimeout)); err != nil {
+			break
+		}
+
 		err := schedule(br, sock)
 		if err == nil {
 			break

--- a/internal/governor/conn_test.go
+++ b/internal/governor/conn_test.go
@@ -1,0 +1,119 @@
+package governor
+
+import "testing"
+
+func TestReadSockstat(t *testing.T) {
+	examples := []struct {
+		label    string
+		environ  []string
+		expected updateData
+	}{
+		{
+			label: "ignored environment",
+			environ: []string{
+				"HTTP_X_SOCKSTAT_repo_name=ignored",
+				"REMOTE_ADDR=ignored",
+				"GIT_SOCKSTAT_VAR_ignored=ignored",
+				"GIT_SOCKSTAT_VAR_user_id=ignored",
+				"GIT_SOCKSTAT_VAR_network_id=bool:false",
+			},
+		},
+		{
+			label: "all the fields",
+			environ: []string{
+				"GIT_SOCKSTAT_VAR_repo_name=a/b",
+				"GIT_SOCKSTAT_VAR_repo_id=uint:1",
+				"GIT_SOCKSTAT_VAR_network_id=uint:2",
+				"GIT_SOCKSTAT_VAR_user_id=uint:3",
+				"GIT_SOCKSTAT_VAR_real_ip=1.2.3.4",
+				"GIT_SOCKSTAT_VAR_request_id=AAAA:BBBB:CCCC-DDDD",
+				"GIT_SOCKSTAT_VAR_user_agent=Testing/1.2.3 xyz=blah",
+				"GIT_SOCKSTAT_VAR_features=random",
+				"GIT_SOCKSTAT_VAR_via=git",
+				"GIT_SOCKSTAT_VAR_ssh_connection=ssh-anything",
+				"GIT_SOCKSTAT_VAR_babeld=babeld-anything",
+				"GIT_SOCKSTAT_VAR_git_protocol=http",
+				"GIT_SOCKSTAT_VAR_pubkey_verifier_id=uint:10",
+				"GIT_SOCKSTAT_VAR_pubkey_creator_id=uint:11",
+			},
+			expected: updateData{
+				RepoName:         "a/b",
+				RepoID:           1,
+				NetworkID:        2,
+				UserID:           3,
+				RealIP:           "1.2.3.4",
+				RequestID:        "AAAA:BBBB:CCCC-DDDD",
+				UserAgent:        "Testing/1.2.3 xyz=blah",
+				Features:         "random",
+				Via:              "git",
+				SSHConnection:    "ssh-anything",
+				Babeld:           "babeld-anything",
+				GitProtocol:      "http",
+				PubkeyVerifierID: 10,
+				PubkeyCreatorID:  11,
+			},
+		},
+	}
+
+	for _, ex := range examples {
+		actual := readSockstat(ex.environ)
+		if actual != ex.expected {
+			t.Errorf("%s: incorrect output\nexpected: %+v\nactual:   %+v\n", ex.label, ex.expected, actual)
+		}
+	}
+}
+
+func TestUint32(t *testing.T) {
+	examples := []struct {
+		input  string
+		output uint32
+	}{
+		{"", 0},
+		{"123", 0},
+		{"abc", 0},
+		{"bool:true", 0},
+		{"bool:false", 0},
+		{"uint:-1", 0},
+		{"uint:1", 1},
+		{"uint:4294967295", 4294967295},
+		{"uint:4294967296", 0},
+		{"uint:4294967297", 0},
+		{"uint:abc", 0},
+		{"uint: 1", 0},
+		{"uint:1 ", 0},
+	}
+
+	for _, ex := range examples {
+		actual := sockstatUint32(ex.input)
+		if actual != ex.output {
+			t.Errorf("sockstatUint32(%q): expected %d, but was %d", ex.input, ex.output, actual)
+		}
+	}
+}
+
+func TestString(t *testing.T) {
+	examples := []struct {
+		input  string
+		output string
+	}{
+		{"", ""},
+		{"123", "123"},
+		{"abc", "abc"},
+		{"bool:true", "true"},
+		{"bool:false", "false"},
+		{"uint:-1", "-1"},
+		{"uint:1", "1"},
+		{"uint:4294967295", "4294967295"},
+		{"uint:4294967296", "4294967296"},
+		{"bool:uint:anything", "uint:anything"},
+		{"uint:bool:anything", "bool:anything"},
+		{"anything:uint:bool", "anything:uint:bool"},
+	}
+
+	for _, ex := range examples {
+		actual := sockstatString(ex.input)
+		if actual != ex.output {
+			t.Errorf("sockstatUint32(%q): expected %q, but was %q", ex.input, ex.output, actual)
+		}
+	}
+}

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -1,13 +1,239 @@
 package governor
 
-import "context"
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+)
 
-func Start(ctx context.Context) *Conn {
-	return nil
+type updateData struct {
+	// The process ID of the process being run. On Linux, this will
+	// usually be ignored by governor in favor of the PID of the process
+	// connecting to the socket.
+	PID int `json:"pid,omitempty"`
+
+	// An ID that identifies a group of commands that all make up one
+	// logical request.
+	GroupID string `json:"group_id,omitempty"`
+
+	// True if this is the top-level request in a group.
+	GroupLeader bool `json:"group_leader,omitempty"`
+
+	// The quality of service for this request. If not set, governor will choose the quality of service to use (probably delayable).
+	QualityOfService string `json:"qos,omitempty"`
+
+	// The name of the program being run.
+	Program string `json:"program,omitempty"`
+
+	// The git directory path.
+	GitDir string `json:"git_dir,omitempty"`
+
+	// The repository's NWO, if available.
+	RepoName string `json:"repo_name,omitempty"`
+
+	// The repository's numerical ID.
+	RepoID uint32 `json:"repo_id,omitempty"`
+
+	// The repository's network ID.
+	NetworkID uint32 `json:"network_id,omitempty"`
+
+	// The ID of the GitHub user on whose behalf this process is being
+	// run.
+	UserID uint32 `json:"user_id,omitempty"`
+
+	// The IP number of the user making the request.
+	RealIP string `json:"real_ip,omitempty"`
+
+	// The request ID of the request that triggered this process.
+	RequestID string `json:"request_id,omitempty"`
+
+	// The User-Agent from the request. For Spokes API requests, this is
+	// the internal client's User-Agent with a spokesd version appended to
+	// it.
+	UserAgent string `json:"user_agent,omitempty"`
+
+	// The X-Spokesd-TLS-Client header from the request. On dotcom, this is
+	// taken from the CN of the client's certificate. In other
+	// environments, this will not be set.
+	ClientApp string `json:"client_app,omitempty"`
+
+	Features         string `json:"features,omitempty"`
+	Via              string `json:"via,omitempty"`
+	SSHConnection    string `json:"ssh_connection,omitempty"`
+	Babeld           string `json:"babeld,omitempty"`
+	GitProtocol      string `json:"git_protocol,omitempty"`
+	PubkeyVerifierID string `json:"pubkey_verifier_id,omitempty"`
+	PubkeyCreatorID  string `json:"pubkey_creator_id,omitempty"`
 }
 
-type Conn struct {
+func update(w io.Writer, ud updateData) error {
+	updateMsg := struct {
+		Command string     `json:"command"`
+		Data    updateData `json:"data"`
+	}{
+		Command: "update",
+		Data:    ud,
+	}
+
+	msg, err := json.Marshal(updateMsg)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(msg)
+	return err
 }
 
-func (c *Conn) Finish(ctx context.Context) {
+type WaitError struct {
+	Duration time.Duration
+}
+
+func newWaitError(duration time.Duration) error {
+	return WaitError{
+		Duration: duration,
+	}
+}
+
+func (err WaitError) Error() string {
+	return fmt.Sprintf("governor asked us to wait %s", err.Duration)
+}
+
+type FailError struct {
+	Reason string
+}
+
+func newFailError(reason string) error {
+	return FailError{
+		Reason: reason,
+	}
+}
+
+func (err FailError) Error() string {
+	return fmt.Sprintf("governor refuses to schedule us: %s", err.Reason)
+}
+
+func schedule(r *bufio.Reader, w io.Writer) error {
+	const msg = `{"command":"schedule"}`
+
+	for {
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			return err
+		}
+
+		b, err := r.ReadBytes('\n')
+		if err != nil {
+			return err
+		}
+
+		line := string(b[:len(b)-1])
+
+		words := strings.SplitN(line, " ", 2)
+		switch words[0] {
+		case "continue":
+			return nil
+		case "wait":
+			duration := 1 * time.Second
+			if len(words) > 1 {
+				d, err := strconv.Atoi(words[1])
+				if err != nil {
+					log.Printf("warning: 'wait' duration %q could not be parsed", words[1])
+				} else {
+					duration = time.Duration(d) * time.Second
+				}
+			}
+			return newWaitError(duration)
+		case "fail":
+			reason := "UNKNOWN"
+			if len(words) > 1 {
+				reason = words[1]
+			}
+			return newFailError(reason)
+		default:
+			return fmt.Errorf("unexpected response %q from governor", line)
+		}
+	}
+}
+
+type finishData struct {
+	// The command's result code.
+	ResultCode uint8 `json:"result_code"`
+
+	// The amount of user plus system CPU used by the command, as an
+	// integer number of milliseconds.
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	CPU uint32 `json:"cpu,omitempty"`
+
+	// The number of times that the filesystem had to perform input.
+	// (Actually, git sends `ru_inblock`, which is the number of times
+	// that the filesystem had to perform input).
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	DiskReadBytes uint64 `json:"disk_read_bytes,omitempty"`
+
+	// The number of bytes written to the filesystem. (Actually, git
+	// sends `ru_outblock`, which is the number of times that the
+	// filesystem had to perform output).
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	DiskWriteBytes uint64 `json:"disk_write_bytes,omitempty"`
+
+	// The maximum resident set size.
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	RSS uint64 `json:"rss,omitempty"`
+
+	// The size of the uploaded packfile, in bytes (implemented only
+	// for `upload-pack`).
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	UploadedBytes uint64 `json:"uploaded_bytes,omitempty"`
+
+	// The size of the received packfile, in bytes (implemented only
+	// for `receive-pack`).
+	//
+	// If this is the GroupLeader, this is an aggregate value for the whole
+	// group.
+	ReceivePackSize uint64 `json:"receive_pack_size,omitempty"`
+
+	// Bitwise OR of:
+	//
+	// * 0x01 — Was this invocation of `upload-pack` a clone (as
+	//   opposed to a fetch)?
+	//
+	// * 0x02 — Was it a shallow (as opposed to a full)
+	//   clone/fetch?
+	Cloning uint8 `json:"cloning,omitempty"`
+
+	// If git died, what was the error message that it emitted?
+	Fatal string `json:"fatal,omitempty"`
+}
+
+func finish(w io.Writer, fd finishData) error {
+	finishMsg := struct {
+		Command string     `json:"command"`
+		Data    finishData `json:"data"`
+	}{
+		Command: "finish",
+		Data:    fd,
+	}
+
+	msg, err := json.Marshal(finishMsg)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(msg)
+	return err
 }

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -1,0 +1,13 @@
+package governor
+
+import "context"
+
+func Start(ctx context.Context) *Conn {
+	return nil
+}
+
+type Conn struct {
+}
+
+func (c *Conn) Finish(ctx context.Context) {
+}

--- a/internal/governor/governor_test.go
+++ b/internal/governor/governor_test.go
@@ -1,0 +1,61 @@
+package governor
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdate(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := update(&buf, updateData{Program: "test-prog"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, `{"command":"update","data":{"program":"test-prog"}}`, buf.String())
+}
+
+func TestSchedule(t *testing.T) {
+	examples := []struct {
+		response      string
+		expectedError error
+	}{
+		{
+			response: "continue\n",
+		},
+		{
+			response:      "wait 100\n",
+			expectedError: WaitError{Duration: 100 * time.Second},
+		},
+		{
+			response:      "fail Too Busy\n",
+			expectedError: FailError{Reason: "Too Busy"},
+		},
+		{
+			response:      "",
+			expectedError: io.EOF,
+		},
+		{
+			response:      "\n",
+			expectedError: errors.New(`unexpected response "" from governor`),
+		},
+	}
+
+	for _, ex := range examples {
+		t.Run(strings.TrimSpace(ex.response), func(t *testing.T) {
+			var toGov bytes.Buffer
+			fromGov := bufio.NewReader(strings.NewReader(ex.response))
+
+			err := schedule(fromGov, &toGov)
+
+			assert.Equal(t, ex.expectedError, err)
+			assert.Equal(t, `{"command":"schedule"}`, toGov.String())
+		})
+	}
+}

--- a/internal/governor/procstats.go
+++ b/internal/governor/procstats.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package governor
+
+import "syscall"
+
+func getProcStats() procStats {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return procStats{}
+	}
+	return procStats{
+		CPU:            uint32(ru.Utime.Sec*1000) + uint32(ru.Utime.Usec/1000) + uint32(ru.Stime.Sec*1000) + uint32(ru.Stime.Usec/1000),
+		RSS:            uint64(ru.Maxrss),
+		DiskReadBytes:  uint64(ru.Inblock),
+		DiskWriteBytes: uint64(ru.Oublock),
+	}
+}

--- a/internal/governor/procstats_linux.go
+++ b/internal/governor/procstats_linux.go
@@ -44,19 +44,19 @@ func getProcStats() procStats {
 			switch {
 			case strings.HasPrefix(line, readPrefix):
 				if val, err := strconv.ParseUint(line[len(readPrefix):], 10, 64); err != nil {
-					res.ReadBytes = val
+					res.DiskReadBytes = val
 				}
 			case strings.HasPrefix(line, writePrefix):
 				if val, err := strconv.ParseUint(line[len(writePrefix):], 10, 64); err != nil {
-					res.WriteBytes = val
+					res.DiskWriteBytes = val
 				}
 			case strings.HasPrefix(line, cancelledWritePrefix):
 				if val, err := strconv.ParseUint(line[len(cancelledWritePrefix):], 10, 64); err != nil {
 					// This always comes after write_bytes.
-					if val > res.WriteBytes {
-						res.WriteBytes = 0
+					if val > res.DiskWriteBytes {
+						res.DiskWriteBytes = 0
 					} else {
-						res.WriteBytes -= val
+						res.DiskWriteBytes -= val
 					}
 				}
 			}

--- a/internal/governor/procstats_linux.go
+++ b/internal/governor/procstats_linux.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package governor
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func getProcStats() procStats {
+	var res procStats
+
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err == nil {
+		res.CPU = uint32(ru.Utime.Sec*1000) + uint32(ru.Utime.Usec/1000) + uint32(ru.Stime.Sec*1000) + uint32(ru.Stime.Usec/1000)
+		res.RSS = uint64(ru.Maxrss)
+	}
+
+	if res.RSS == 0 {
+		pageSize := syscall.Getpagesize()
+		if pageSize > 0 {
+			stat, err := os.ReadFile("/proc/self/stat")
+			if err == nil {
+				fields := bytes.Fields(stat)
+				if len(fields) > 23 {
+					res.RSS, _ = strconv.ParseUint(fields[23], 10, 64)
+				}
+			}
+		}
+	}
+
+	iostats, err := os.ReadFile("/proc/self/io")
+	if err == nil {
+		const (
+			readPrefix           = "read_bytes: "
+			writePrefix          = "write_bytes: "
+			cancelledWritePrefix = "cancelled_write_bytes: "
+		)
+		for _, line := range strings.Split(string(iostats), "\n") {
+			switch {
+			case strings.HasPrefix(line, readPrefix):
+				if val, err := strconv.ParseUint(line[len(readPrefix):], 10, 64); err != nil {
+					res.ReadBytes = val
+				}
+			case strings.HasPrefix(line, writePrefix):
+				if val, err := strconv.ParseUint(line[len(writePrefix):], 10, 64); err != nil {
+					res.WriteBytes = val
+				}
+			case strings.HasPrefix(line, cancelledWritePrefix):
+				if val, err := strconv.ParseUint(line[len(cancelledWritePrefix):], 10, 64); err != nil {
+					// This always comes after write_bytes.
+					if val > res.WriteBytes {
+						res.WriteBytes = 0
+					} else {
+						res.WriteBytes -= val
+					}
+				}
+			}
+		}
+	}
+
+	return res
+}

--- a/internal/governor/procstats_linux.go
+++ b/internal/governor/procstats_linux.go
@@ -27,7 +27,10 @@ func getProcStats() procStats {
 			if err == nil {
 				fields := bytes.Fields(stat)
 				if len(fields) > 23 {
-					res.RSS, _ = strconv.ParseUint(fields[23], 10, 64)
+					val, err := strconv.ParseUint(string(fields[23]), 10, 64)
+					if err == nil {
+						res.RSS = val * uint64(pageSize)
+					}
 				}
 			}
 		}
@@ -79,10 +82,10 @@ func getPeakRSS() uint64 {
 		return 0
 	}
 
-	val, err := strconv.Parse(string(stat[i:]), 10, 64)
+	val, err := strconv.ParseUint(string(stat[i:]), 10, 64)
 	if err != nil {
 		return 0
 	}
 
-	return val
+	return val * 1024
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -132,6 +132,8 @@ func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
 
 	cmd := exec.Command("git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r")
 	cmd.Env = append(os.Environ(), "GIT_SOCKSTAT_PATH="+govSock)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
 
 	assert.NoError(suite.T(), os.Chdir(suite.localRepo), "unable to chdir into our local Git repo")
 	assert.NoError(suite.T(), cmd.Run(),
@@ -146,7 +148,15 @@ func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
 	})
 	requireGovernorMessage(suite.T(), timeout, msgs, func(msg govMessage) {
 		assert.Equal(suite.T(), "finish", msg.Command)
-		assert.ElementsMatch(suite.T(), []string{"result_code", "receive_pack_size"}, keys(msg.Data))
+		// This varies by platform:
+		// assert.ElementsMatch(suite.T(), []string{
+		// 	"result_code",
+		// 	"receive_pack_size",
+		// 	"cpu",
+		// 	"rss",
+		// 	"read_bytes",
+		// 	"write_bytes",
+		// }, keys(msg.Data))
 		assert.Equal(suite.T(), float64(0), msg.Data["result_code"])
 		assert.Truef(suite.T(), msg.Data["receive_pack_size"].(float64) > 3000, "expect receive_pack_size (%v) to be at least 3000 bytes", msg.Data["receive_pack_size"])
 	})

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -146,8 +146,9 @@ func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
 	})
 	requireGovernorMessage(suite.T(), timeout, msgs, func(msg govMessage) {
 		assert.Equal(suite.T(), "finish", msg.Command)
-		assert.ElementsMatch(suite.T(), []string{"result_code"}, keys(msg.Data))
+		assert.ElementsMatch(suite.T(), []string{"result_code", "receive_pack_size"}, keys(msg.Data))
 		assert.Equal(suite.T(), float64(0), msg.Data["result_code"])
+		assert.Truef(suite.T(), msg.Data["receive_pack_size"].(float64) > 3000, "expect receive_pack_size (%v) to be at least 3000 bytes", msg.Data["receive_pack_size"])
 	})
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -4,14 +4,18 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/github/go-pipe/pipe"
 	"github.com/stretchr/testify/assert"
@@ -120,6 +124,94 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackMultiplePush() {
 		exec.Command(
 			"git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r").Run(),
 		"unexpected error running the push with the custom spokes-receive-pack program")
+}
+
+func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
+	govSock, msgs, cleanup := startFakeGovernor(suite.T())
+	defer cleanup()
+
+	cmd := exec.Command("git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r")
+	cmd.Env = append(os.Environ(), "GIT_SOCKSTAT_PATH="+govSock)
+
+	assert.NoError(suite.T(), os.Chdir(suite.localRepo), "unable to chdir into our local Git repo")
+	assert.NoError(suite.T(), cmd.Run(),
+		"unexpected error running the push with the custom spokes-receive-pack program")
+
+	timeout := time.After(time.Second)
+	requireGovernorMessage(suite.T(), timeout, msgs, func(msg govMessage) {
+		assert.Equal(suite.T(), "update", msg.Command)
+		assert.ElementsMatch(suite.T(), []string{"pid", "program", "git_dir"}, keys(msg.Data))
+		assert.Equal(suite.T(), "spokes-receive-pack", msg.Data["program"])
+	})
+	requireGovernorMessage(suite.T(), timeout, msgs, func(msg govMessage) {
+		assert.Equal(suite.T(), "finish", msg.Command)
+		assert.ElementsMatch(suite.T(), []string{"result_code"}, keys(msg.Data))
+		assert.Equal(suite.T(), float64(0), msg.Data["result_code"])
+	})
+}
+
+func startFakeGovernor(t *testing.T) (string, <-chan govMessage, func()) {
+	tmpdir, err := os.MkdirTemp("", "spokes-receive-pack-governor-*")
+	require.NoError(t, err)
+	cleanup := func() { os.RemoveAll(tmpdir) }
+
+	sockpath := filepath.Join(tmpdir, "gov.sock")
+	t.Logf("fake gov listening on %s", sockpath)
+	l, err := net.Listen("unix", sockpath)
+	require.NoError(t, err)
+
+	msgs := make(chan govMessage, 2)
+	go func() {
+		defer l.Close()
+		defer close(msgs)
+		conn, err := l.Accept()
+		if err != nil {
+			t.Logf("gov: accept error: %v", err)
+			return
+		}
+		t.Logf("gov accepted on %s", sockpath)
+		decoder := json.NewDecoder(conn)
+		for {
+			var msg govMessage
+			err := decoder.Decode(&msg)
+			if err != nil {
+				if err != io.EOF {
+					t.Logf("gov: read error: %v", err)
+				}
+				break
+			}
+			if msg.Command == "schedule" {
+				conn.Write([]byte("continue\n"))
+			} else {
+				msgs <- msg
+			}
+		}
+	}()
+
+	return sockpath, msgs, cleanup
+}
+
+type govMessage struct {
+	Command string                 `json:"command"`
+	Data    map[string]interface{} `json:"data"`
+}
+
+func requireGovernorMessage(t *testing.T, timeout <-chan time.Time, msgs <-chan govMessage, verify func(msg govMessage)) {
+	select {
+	case msg, ok := <-msgs:
+		require.True(t, ok)
+		verify(msg)
+	case <-timeout:
+		t.Fatal("timed out waiting for gov message from spokes-receive-pack")
+	}
+}
+
+func keys(m map[string]interface{}) []string {
+	var res []string
+	for k := range m {
+		res = append(res, k)
+	}
+	return res
 }
 
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackMultiplePushWithExtraReceiveOptions() {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -142,6 +142,7 @@ func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
 		assert.Equal(suite.T(), "update", msg.Command)
 		assert.ElementsMatch(suite.T(), []string{"pid", "program", "git_dir"}, keys(msg.Data))
 		assert.Equal(suite.T(), "spokes-receive-pack", msg.Data["program"])
+		assert.Equal(suite.T(), filepath.Base(suite.remoteRepo), filepath.Base(msg.Data["git_dir"].(string))) // avoid problems from non-canonical paths, e.g. on macOS with its /tmp symlink.
 	})
 	requireGovernorMessage(suite.T(), timeout, msgs, func(msg govMessage) {
 		assert.Equal(suite.T(), "finish", msg.Command)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -158,7 +158,9 @@ func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {
 		// 	"write_bytes",
 		// }, keys(msg.Data))
 		assert.Equal(suite.T(), float64(0), msg.Data["result_code"])
-		assert.Truef(suite.T(), msg.Data["receive_pack_size"].(float64) > 3000, "expect receive_pack_size (%v) to be at least 3000 bytes", msg.Data["receive_pack_size"])
+		assert.Truef(suite.T(), msg.Data["receive_pack_size"].(float64) > 0, "expect receive_pack_size (%v) to be more than 0", msg.Data["receive_pack_size"])
+		assert.Truef(suite.T(), msg.Data["cpu"].(float64) > 0, "expect cpu (%v) to be more than 0", msg.Data["cpu"])
+		assert.Truef(suite.T(), msg.Data["rss"].(float64) > 0, "expect rss (%v) to be more than 0", msg.Data["rss"])
 	})
 }
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -32,11 +32,12 @@ const (
 
 // SpokesReceivePack is used to model our own impl of the git-receive-pack
 type SpokesReceivePack struct {
+	RepoPath string
+
 	input            io.Reader
 	output           io.Writer
 	err              io.Writer
 	capabilities     string
-	RepoPath         string
 	config           *config.Config
 	statelessRPC     bool
 	advertiseRefs    bool

--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -18,37 +18,42 @@ const GitSockstatVarSpokesQuarantine = "GIT_SOCKSTAT_VAR_spokes_quarantine"
 var BuildVersion string
 
 func main() {
-	if err := mainImpl(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]); err != nil {
+	exitCode, err := mainImpl(os.Stdin, os.Stdout, os.Stderr, os.Args[1:])
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
 	}
+	os.Exit(exitCode)
 }
 
-func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
+func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) (int, error) {
 	ctx := context.Background()
 	if os.Getenv(GitSockstatVarSpokesQuarantine) != "bool:true" {
 		rp := receivepack.NewReceivePack(stdin, stdout, stderr, args)
 		if err := rp.Execute(ctx); err != nil {
-			return fmt.Errorf("unexpected error running receive pack: %w", err)
+			return 1, fmt.Errorf("unexpected error running receive pack: %w", err)
 		}
-	} else {
-		ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-		defer stop()
 
-		g, err := governor.Start(ctx)
-		if err != nil {
-			return err
-		}
-		defer g.Finish(ctx)
-
-		rp, err := spokes.NewSpokesReceivePack(stdin, stdout, stderr, args, BuildVersion)
-		if err != nil {
-			return err
-		}
-		if err := rp.Execute(ctx); err != nil {
-			return fmt.Errorf("unexpected error running spokes receive pack: %w", err)
-		}
+		return 0, nil
 	}
 
-	return nil
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	defer stop()
+
+	g, err := governor.Start(ctx)
+	if err != nil {
+		return 75, err
+	}
+	defer g.Finish(ctx)
+
+	rp, err := spokes.NewSpokesReceivePack(stdin, stdout, stderr, args, BuildVersion)
+	if err != nil {
+		g.SetError(1, err.Error())
+		return 1, err
+	}
+	if err := rp.Execute(ctx); err != nil {
+		g.SetError(1, err.Error())
+		return 1, fmt.Errorf("unexpected error running spokes receive pack: %w", err)
+	}
+
+	return 0, nil
 }

--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -35,7 +35,10 @@ func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
 		ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 		defer stop()
 
-		g := governor.Start(ctx)
+		g, err := governor.Start(ctx)
+		if err != nil {
+			return err
+		}
 		defer g.Finish(ctx)
 
 		rp, err := spokes.NewSpokesReceivePack(stdin, stdout, stderr, args, BuildVersion)

--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -44,7 +44,7 @@ func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) (int, er
 		return 1, err
 	}
 
-	g, err := governor.Start(ctx)
+	g, err := governor.Start(ctx, rp.RepoPath)
 	if err != nil {
 		return 75, err
 	}


### PR DESCRIPTION
Governor is GitHub's per-node resource monitor. It tracks all Git activity on the server so that it can slow down excessive accesses, which helps shorten periods of high resource use and helps preserve capacity for as many customers as possible. Spokes-receive-pack doesn't do a ton of work itself, but still needs to dial into governor so that governor can do its job.

Closes https://github.com/github/git-access/issues/75

cc @migue @jasonuhl @mhagger @AshwinMohan86 