### PR TITLE
Handle ref deletion better

### DIFF
--- a/internal/integration/chdir.go
+++ b/internal/integration/chdir.go
@@ -15,6 +15,7 @@ func chdir(t *testing.T, dir string) error {
 		return err
 	}
 
+	t.Logf("chdir %q", dir)
 	if err := os.Chdir(dir); err != nil {
 		return err
 	}
@@ -24,6 +25,7 @@ func chdir(t *testing.T, dir string) error {
 		// tmpdir that got removed. In that case, we'll just log it,
 		// and trust that there's another cleanup func ready to change
 		// back to the original working dir.
+		t.Logf("cleanup chdir %q", wd)
 		if err := os.Chdir(wd); err != nil {
 			t.Logf("error calling chdir(%q) during cleanup: %v", wd, err)
 		}

--- a/internal/integration/hiderefs_test.go
+++ b/internal/integration/hiderefs_test.go
@@ -69,7 +69,7 @@ func TestHiderefsConfig(t *testing.T) {
 		"GIT_CONFIG_PARAMETERS="+gitConfigParameters,
 		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
-	srp.Stderr = os.Stderr
+	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)
 	srpOut, err := srp.StdoutPipe()

--- a/internal/integration/logshim.go
+++ b/internal/integration/logshim.go
@@ -1,0 +1,14 @@
+//go:build integration
+
+package integration
+
+import "testing"
+
+type testLogWriter struct {
+	t *testing.T
+}
+
+func (w *testLogWriter) Write(data []byte) (int, error) {
+	w.t.Logf("%s", data)
+	return len(data), nil
+}

--- a/internal/integration/missingobjects_test.go
+++ b/internal/integration/missingobjects_test.go
@@ -49,7 +49,7 @@ func TestMissingObjects(t *testing.T) {
 	srp.Env = append(os.Environ(),
 		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
-	srp.Stderr = os.Stderr
+	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)
 	srpOut, err := srp.StdoutPipe()

--- a/internal/integration/missingobjects_test.go
+++ b/internal/integration/missingobjects_test.go
@@ -22,12 +22,13 @@ func TestMissingObjects(t *testing.T) {
 		OldOID string `json:"push_from"`
 		NewOID string `json:"push_to"`
 		Ref    string `json:"ref"`
+		DelRef string `json:"extra_ref"`
 	}
 	const (
-		remote   = "testdata/missing-objects/remote.git"
-		badPack  = "testdata/missing-objects/bad.pack"
-		infoFile = "testdata/missing-objects/info.json"
-		otherRef = "refs/heads/other"
+		remote      = "testdata/missing-objects/remote.git"
+		badPack     = "testdata/missing-objects/bad.pack"
+		infoFile    = "testdata/missing-objects/info.json"
+		refToCreate = "refs/heads/new-branch"
 	)
 
 	infoJSON, err := os.ReadFile(infoFile)
@@ -38,8 +39,7 @@ func TestMissingObjects(t *testing.T) {
 	require.NoError(t, err)
 
 	testRepo := t.TempDir()
-	requireRun(t, "git", "init", "--bare", testRepo)
-	requireRun(t, "git", "-C", testRepo, "fetch", origin, info.Ref+":"+info.Ref)
+	requireRun(t, "git", "clone", "--mirror", origin, testRepo)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -63,7 +63,8 @@ func TestMissingObjects(t *testing.T) {
 	refs, _, err := readAdv(bufSRPOut)
 	require.NoError(t, err)
 	assert.Equal(t, refs, map[string]string{
-		info.Ref: info.OldOID,
+		info.Ref:    info.OldOID,
+		info.DelRef: info.OldOID,
 	})
 
 	// Try to update the ref that's already there to commit C (but we won't
@@ -71,10 +72,17 @@ func TestMissingObjects(t *testing.T) {
 	require.NoError(t, writePktlinef(srpIn,
 		"%s %s %s\x00report-status report-status-v2 side-band-64k object-format=sha1\n",
 		info.OldOID, info.NewOID, info.Ref))
+
 	// Try to create another ref with a commit that the remote already has.
 	require.NoError(t, writePktlinef(srpIn,
 		"%040d %s %s",
-		0, info.OldOID, otherRef))
+		0, info.OldOID, refToCreate))
+
+	// Try to delete another ref.
+	require.NoError(t, writePktlinef(srpIn,
+		"%s %040d %s",
+		info.OldOID, 0, info.DelRef))
+
 	_, err = srpIn.Write([]byte("0000"))
 	require.NoError(t, err)
 
@@ -90,8 +98,9 @@ func TestMissingObjects(t *testing.T) {
 	refStatus, unpackRes, _, err := readResult(t, bufSRPOut)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		info.Ref: "ng missing necessary objects",
-		otherRef: "ok",
+		info.Ref:    "ng missing necessary objects",
+		info.DelRef: "ok",
+		refToCreate: "ok",
 	}, refStatus)
 	assert.Equal(t, "unpack ok\n", unpackRes)
 }

--- a/internal/integration/nosideband_test.go
+++ b/internal/integration/nosideband_test.go
@@ -42,7 +42,7 @@ func TestNoSideBand(t *testing.T) {
 	srp.Env = append(os.Environ(),
 		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
-	srp.Stderr = os.Stderr
+	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)
 	srpOut, err := srp.StdoutPipe()

--- a/internal/integration/parse.go
+++ b/internal/integration/parse.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -145,7 +144,6 @@ func readPktline(r io.Reader) ([]byte, error) {
 	if n != 4 {
 		return nil, fmt.Errorf("expected 4 bytes but got %d (%s)", n, sizeBuf[:n])
 	}
-	log.Printf("read pkt size: %s", sizeBuf)
 
 	size, err := strconv.ParseUint(string(sizeBuf), 16, 16)
 	if err != nil {
@@ -161,7 +159,6 @@ func readPktline(r io.Reader) ([]byte, error) {
 
 	buf := make([]byte, size-4)
 	n, err = io.ReadFull(r, buf)
-	log.Printf("read pkt data: %q", string(buf[:n]))
 	return buf, err
 }
 

--- a/internal/integration/pushoptions_test.go
+++ b/internal/integration/pushoptions_test.go
@@ -41,7 +41,7 @@ func TestPushOptions(t *testing.T) {
 	srp.Env = append(os.Environ(),
 		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
-	srp.Stderr = os.Stderr
+	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)
 	srpOut, err := srp.StdoutPipe()

--- a/internal/integration/testdata/missing-objects/info.json
+++ b/internal/integration/testdata/missing-objects/info.json
@@ -1,5 +1,6 @@
 {
   "push_from": "6389baef05c2b5e5c9f603daa23df53e71bdf591",
   "push_to": "04ae1b030995df0ae3e91c41d1a065aaae405397",
-  "ref": "refs/heads/example"
+  "ref": "refs/heads/example",
+  "extra_ref": "refs/heads/other"
 }

--- a/internal/integration/testdata/missing-objects/remote.git/info/refs
+++ b/internal/integration/testdata/missing-objects/remote.git/info/refs
@@ -1,1 +1,2 @@
 6389baef05c2b5e5c9f603daa23df53e71bdf591	refs/heads/example
+6389baef05c2b5e5c9f603daa23df53e71bdf591	refs/heads/other

--- a/internal/integration/testdata/missing-objects/remote.git/packed-refs
+++ b/internal/integration/testdata/missing-objects/remote.git/packed-refs
@@ -1,0 +1,3 @@
+# pack-refs with: peeled fully-peeled sorted 
+6389baef05c2b5e5c9f603daa23df53e71bdf591 refs/heads/example
+6389baef05c2b5e5c9f603daa23df53e71bdf591 refs/heads/other

--- a/internal/integration/testdata/missing-objects/remote.git/refs/heads/example
+++ b/internal/integration/testdata/missing-objects/remote.git/refs/heads/example
@@ -1,1 +1,0 @@
-6389baef05c2b5e5c9f603daa23df53e71bdf591

--- a/internal/integration/testdata/set-up-missing-objects-push
+++ b/internal/integration/testdata/set-up-missing-objects-push
@@ -15,7 +15,7 @@
 #/
 #/ Outputs:
 #/   internal/integration/testdata/missing-objects/remote.git
-#/   - Valid repository with A as its main branch.
+#/   - Valid repository with A as its default ("example") and "other" branches.
 #/   internal/integration/testdata/missing-objects/info.json
 #/   - oid of A, oid of C, name of ref to update.
 #/   internal/integration/testdata/missing-objects/bad.pack
@@ -25,7 +25,8 @@ set -e
 set -o nounset
 set -o pipefail
 
-BRANCH=example
+DEFAULT_BRANCH=example
+EXTRA_BRANCH=other
 
 set -x
 
@@ -34,10 +35,10 @@ rm -rf missing-objects
 mkdir missing-objects
 cd missing-objects
 
-git init --bare --quiet -b $BRANCH remote.git
+git init --bare --quiet -b $DEFAULT_BRANCH remote.git
 rm -rf remote.git/hooks remote.git/info/exclude
 
-git init --bare --quiet -b $BRANCH work.git
+git init --bare --quiet -b $DEFAULT_BRANCH work.git
 cd work.git
 
 #/fi/ commit refs/heads/__BRANCH__
@@ -58,7 +59,7 @@ cd work.git
 #/fi/ commit C
 #/fi/ EOC
 #/fi/
-grep "^#/fi/ " ../../$(basename "$0") | cut -c7- | sed -e "s/__BRANCH__/$BRANCH/" \
+grep "^#/fi/ " ../../$(basename "$0") | cut -c7- | sed -e "s/__BRANCH__/$DEFAULT_BRANCH/" \
 | git fast-import --quiet
 
 git --no-pager log --graph --all
@@ -66,10 +67,10 @@ COMMIT_C=$(git rev-parse example)
 COMMIT_B=$(git rev-parse example~)
 COMMIT_A=$(git rev-parse example~~)
 
-git push ../remote.git $COMMIT_A:refs/heads/$BRANCH
+git push ../remote.git $COMMIT_A:refs/heads/$DEFAULT_BRANCH $COMMIT_A:refs/heads/$EXTRA_BRANCH
 
 # Tell the test to update the ref from A -> C.
-printf '{"push_from":"%s","push_to":"%s","ref":"refs/heads/%s"}' "$COMMIT_A" "$COMMIT_C" "$BRANCH" \
+printf '{"push_from":"%s","push_to":"%s","ref":"refs/heads/%s","extra_ref":"refs/heads/%s"}' "$COMMIT_A" "$COMMIT_C" "$DEFAULT_BRANCH" "$EXTRA_BRANCH" \
 | jq . | tee ../info.json
 
 # Only include commit C in the pack.
@@ -84,8 +85,13 @@ rm -rf work.git
 
 cd remote.git
 git repack -adf
+git pack-refs --all
+# Make sure Git doesn't delete the refs dir.
+touch refs/.keep
 # This should only show commit A.
 git --no-pager log example --graph --all
 
 cd ..
 find . -type f -ls
+
+echo DONE


### PR DESCRIPTION
This branch fixes pushes when all updates are ref deletions. In this case, spokes-receive-pack would end up feeding an empty list to git-rev-list for the connectivity check, which would fail, and then it would do its per-ref connectivity and not find `0000000000000000000000000000000000000000`.

Along the way, I cleaned up the test output from the integration suite. The result should be that output is grouped by test and only shown for failing tests (or if -v is given to go test). I hope it's a little clearer now and easier to piece together what's going on when a test fails.

I also made spokes-receive-pack avoid a race when it looks for the new pack file's name in the output from index-pack. This should make `TestSpokesReceivePackTestSuite/TestWithGovernor` less flaky. (https://github.com/github/spokes-receive-pack/pull/41#discussion_r1159907696 is a similar change.)

cc github/git-access#56 @migue @derrickstolee 