### PR TITLE
Don't leave quarantine folders behind

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -79,7 +79,6 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		return 1, err
 	}
 
-	quarantineFolder := filepath.Join(repoPath, "objects", quarantineID)
 	rp := &spokesReceivePack{
 		input:            stdin,
 		output:           stdout,
@@ -89,7 +88,7 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		config:           config,
 		statelessRPC:     *statelessRPC,
 		advertiseRefs:    *httpBackendInfoRefs,
-		quarantineFolder: quarantineFolder,
+		quarantineFolder: filepath.Join(repoPath, "objects", quarantineID),
 		governor:         g,
 	}
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -97,12 +97,7 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 
 	if err := rp.execute(ctx); err != nil {
 		g.SetError(1, err.Error())
-
-		// Let's make sure we don't leave any quarantine files behind if something goes wrong
-		// If the error has happened before we have created the quarantine dir, we don't need to remove it, but RemoveAll won't fail
-		// If the error has happened after we have created the quarantine dir, the folder will be removed
-		_ = os.RemoveAll(quarantineFolder)
-
+		rp.Close()
 		return 1, fmt.Errorf("unexpected error running spokes receive pack: %w", err)
 	}
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -107,6 +107,18 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 	return 0, nil
 }
 
+func registerShutdownHooks(hooks ...io.Closer) {
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		<-c
+		for _, hook := range hooks {
+			hook.Close()
+		}
+		os.Exit(1)
+	}()
+}
+
 // spokesReceivePack is used to model our own impl of the git-receive-pack
 type spokesReceivePack struct {
 	input            io.Reader

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -93,6 +93,8 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		governor:         g,
 	}
 
+	registerShutdownHooks(rp)
+
 	if err := rp.execute(ctx); err != nil {
 		g.SetError(1, err.Error())
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -135,6 +135,13 @@ type spokesReceivePack struct {
 	governor         *governor.Conn
 }
 
+func (r *spokesReceivePack) Close() error {
+	// Let's make sure we don't leave any quarantine files behind if something goes wrong
+	// If the error has happened before we have created the quarantine dir, we don't need to remove it, but RemoveAll won't fail
+	// If the error has happened after we have created the quarantine dir, the folder will be removed
+	return os.RemoveAll(r.quarantineFolder)
+}
+
 // execute executes our custom implementation
 // It tries to model the behaviour described in the "Pushing Data To a Server" section of the
 // https://github.com/github/git/blob/github/Documentation/technical/pack-protocol.txt document

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -205,6 +205,12 @@ func (r *spokesReceivePack) execute(ctx context.Context) error {
 		}
 	}
 
+	failpoint.Inject("unpack-error", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(errors.New("error performing the unpack process"))
+		}
+	})
+
 	if unpackErr != nil {
 		return fmt.Errorf("index-pack: %w", unpackErr)
 	}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -79,6 +79,7 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		return 1, err
 	}
 
+	quarantineFolder := filepath.Join(repoPath, "objects", quarantineID)
 	rp := &spokesReceivePack{
 		input:            stdin,
 		output:           stdout,
@@ -88,12 +89,18 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		config:           config,
 		statelessRPC:     *statelessRPC,
 		advertiseRefs:    *httpBackendInfoRefs,
-		quarantineFolder: filepath.Join(repoPath, "objects", quarantineID),
+		quarantineFolder: quarantineFolder,
 		governor:         g,
 	}
 
 	if err := rp.execute(ctx); err != nil {
 		g.SetError(1, err.Error())
+
+		// Let's make sure we don't leave any quarantine files behind if something goes wrong
+		// If the error has happened before we have created the quarantine dir, we don't need to remove it, but RemoveAll won't fail
+		// If the error has happened after we have created the quarantine dir, the folder will be removed
+		_ = os.RemoveAll(quarantineFolder)
+
 		return 1, fmt.Errorf("unexpected error running spokes receive pack: %w", err)
 	}
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -101,13 +101,6 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 	return 0, nil
 }
 
-func (r *spokesReceivePack) cleanQuarantineOnContextDone(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		r.RemoveQuarantine()
-	}()
-}
-
 // spokesReceivePack is used to model our own impl of the git-receive-pack
 type spokesReceivePack struct {
 	input            io.Reader
@@ -133,8 +126,6 @@ func (r *spokesReceivePack) RemoveQuarantine() {
 // It tries to model the behaviour described in the "Pushing Data To a Server" section of the
 // https://github.com/github/git/blob/github/Documentation/technical/pack-protocol.txt document
 func (r *spokesReceivePack) execute(ctx context.Context) error {
-	r.cleanQuarantineOnContextDone(ctx)
-
 	// Reference discovery phase
 	// We only need to perform the references discovery when we are not using the HTTP protocol or, if we are using it,
 	// we only run the discovery phase when the http-backend-info-refs/advertise-refs option has been set


### PR DESCRIPTION
We discovered certain repos where quarantine folders were left behind, causing difficulties with some of the procedures performed on every repo on a regular basis.

With this change, we try to prevent leaving any quarantine folder behind if an unexpected error happens during the execution of the process.

This isn't the only area where a quarantine folder could be left behind; if something goes wrong in Babeld while running the pre-receive-hooks and we don't get to execute the `_commit_refs`, we won't be properly removing the quarantine folder, leaving it behind. Will take a look and see what can be done there, but I thought opening this pull would be something useful as well
