### PR TITLE
Add 'session-id' to spokes-receive-pack's capabilities

### DIFF
--- a/internal/integration/capabilities_test.go
+++ b/internal/integration/capabilities_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package integration
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/github/spokes-receive-pack/internal/pktline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapabilities(t *testing.T) {
+	const (
+		defaultBranch  = "refs/heads/main"
+		transferhide1  = "refs/__transferhiderefs1/example/anything"
+		transferhide2  = "refs/__transferhiderefs2/example/anything"
+		transferunhide = "refs/__transferhiderefs2/exception/anything" // nested inside of __transferhiderefs2
+		receivehide1   = "refs/__receivehiderefs1/example/anything"
+		receivehide2   = "refs/__receivehiderefs2/example/anything"
+		uploadhide     = "refs/__uploadhiderefs/example/anything"
+
+		createBranch         = "refs/heads/newbranch"
+		createtransferhide1  = "refs/__transferhiderefs1/example/new"
+		createtransferhide2  = "refs/__transferhiderefs2/example/new"
+		createtransferunhide = "refs/__transferhiderefs2/exception/new" // nested inside of __transferhiderefs2
+		createreceivehide1   = "refs/__receivehiderefs1/example/new"
+		createreceivehide2   = "refs/__receivehiderefs2/example/new"
+		createuploadhide     = "refs/__uploadhiderefs/example/new"
+
+		// This needs to be reachable from refs/heads/main
+		testCommit = "e589bdee50e39beac56220c4b7a716225f79e3cf"
+
+		gitConfigParameters = `'transfer.hideRefs=refs/__transferhiderefs2' ` +
+			`'transfer.hideRefs='\!'refs/__transferhiderefs2/exception' ` +
+			`'receive.hideRefs=refs/__receivehiderefs2'`
+	)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	origin := filepath.Join(wd, "testdata/remote/git-internals-fork.git")
+
+	testRepo := t.TempDir()
+	requireRun(t, "git", "init", "--bare", testRepo)
+	requireRun(t, "git", "-C", testRepo, "fetch", origin, defaultBranch+":"+defaultBranch)
+
+	getCapsAdv := func(ctx context.Context, t *testing.T, extraEnv ...string) pktline.Capabilities {
+		srp := exec.CommandContext(ctx, "spokes-receive-pack", "--stateless-rpc", "--advertise-refs", ".")
+		srp.Dir = testRepo
+		srp.Env = append(os.Environ(),
+			"GIT_CONFIG_PARAMETERS="+gitConfigParameters,
+			"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
+			"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
+		srp.Env = append(srp.Env, extraEnv...)
+		srp.Stderr = &testLogWriter{t}
+		srpOut, err := srp.StdoutPipe()
+		require.NoError(t, err)
+		srp.Start()
+
+		bufSRPOut := bufio.NewReader(srpOut)
+		_, capsLine, err := readAdv(bufSRPOut)
+		require.NoError(t, err)
+		caps, err := pktline.ParseCapabilities([]byte(capsLine))
+		require.NoError(t, err)
+
+		assert.NoError(t, srp.Wait())
+
+		return caps
+	}
+
+	t.Run("with request id", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		caps := getCapsAdv(ctx, t, "GIT_SOCKSTAT_VAR_request_id=test:request:id")
+
+		assert.Equal(t, []string{
+			"agent",
+			"atomic",
+			"delete-refs",
+			"object-format",
+			"ofs-delta",
+			"push-options",
+			"quiet",
+			"report-status",
+			"report-status-v2",
+			"session-id",
+			"side-band-64k",
+		}, caps.Names())
+
+		assert.Equal(t, caps.SessionId().Value(), "test:request:id")
+		assert.Equal(t, caps.ObjectFormat().Value(), "sha1")
+		assert.Regexp(t, "^github/spokes-receive-pack-[0-9a-f]+$", caps.Agent().Value())
+	})
+
+	t.Run("without request id", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		caps := getCapsAdv(ctx, t)
+
+		assert.Equal(t, []string{
+			"agent",
+			"atomic",
+			"delete-refs",
+			"object-format",
+			"ofs-delta",
+			"push-options",
+			"quiet",
+			"report-status",
+			"report-status-v2",
+			"side-band-64k",
+		}, caps.Names())
+
+		assert.Equal(t, caps.ObjectFormat().Value(), "sha1")
+		assert.Regexp(t, "^github/spokes-receive-pack-[0-9a-f]+$", caps.Agent().Value())
+	})
+}

--- a/internal/pktline/capabilities.go
+++ b/internal/pktline/capabilities.go
@@ -190,3 +190,15 @@ func (c Capabilities) IsDefined(cap string) bool {
 	_, found := c.caps[cap]
 	return found
 }
+
+func IsSafeCapabilityValue(val string) bool {
+	// Git needs this not to include \r, \n, \t, or ' '.
+	// https://github.com/git/git/blob/d7d8841f67f29e6ecbad85a11805c907d0f00d5d/connect.c#L629
+	for _, b := range []byte(val) {
+		switch b {
+		case ' ', '\r', '\n', '\t':
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pktline/capabilities.go
+++ b/internal/pktline/capabilities.go
@@ -2,6 +2,7 @@ package pktline
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -169,6 +170,15 @@ func (c Capabilities) Filter() Capability {
 }
 func (c Capabilities) SessionId() Capability {
 	return c.caps[SessionId]
+}
+
+func (c Capabilities) Names() []string {
+	res := make([]string, 0, len(c.caps))
+	for k := range c.caps {
+		res = append(res, k)
+	}
+	sort.Strings(res)
+	return res
 }
 
 func (c Capabilities) Get(cap string) (Capability, bool) {

--- a/internal/pktline/capabilities_test.go
+++ b/internal/pktline/capabilities_test.go
@@ -75,6 +75,26 @@ func TestParseCapabilitiesWithArguments(t *testing.T) {
 }
 
 func TestSafeCapabilityValue(t *testing.T) {
+	for _, p := range []struct {
+		val      string
+		expected bool
+	}{
+		{"", true},
+		{"AA:BB:CC:01", true},
+		{"abcdefg", true},
+		{"not valid", false},
+		{"not\tvalid", false},
+		{"not\rvalid", false},
+		{"not\nvalid", false},
+	} {
+		t.Run(
+			fmt.Sprintf("TestSafeCapabilityValue(%s)", p.val),
+			func(t *testing.T) {
+				assert.Equal(t, p.expected, IsSafeCapabilityValue(p.val))
+			},
+		)
+	}
+}
 	good := []string{
 		"",
 		"AA:BB:CC:01",

--- a/internal/pktline/capabilities_test.go
+++ b/internal/pktline/capabilities_test.go
@@ -75,7 +75,7 @@ func TestParseCapabilitiesWithArguments(t *testing.T) {
 }
 
 func TestSafeCapabilityValue(t *testing.T) {
-	for _, p := range []struct {
+	examples := []struct {
 		val      string
 		expected bool
 	}{
@@ -86,33 +86,9 @@ func TestSafeCapabilityValue(t *testing.T) {
 		{"not\tvalid", false},
 		{"not\rvalid", false},
 		{"not\nvalid", false},
-	} {
-		t.Run(
-			fmt.Sprintf("TestSafeCapabilityValue(%s)", p.val),
-			func(t *testing.T) {
-				assert.Equal(t, p.expected, IsSafeCapabilityValue(p.val))
-			},
-		)
-	}
-}
-	good := []string{
-		"",
-		"AA:BB:CC:01",
-		"abcdefg",
 	}
 
-	for _, s := range good {
-		assert.True(t, IsSafeCapabilityValue(s), "%q should be ok", s)
-	}
-
-	bad := []string{
-		"not valid",
-		"not\tvalid",
-		"not\rvalid",
-		"not\nvalid",
-	}
-
-	for _, s := range bad {
-		assert.False(t, IsSafeCapabilityValue(s), "%q should not be ok", s)
+	for _, ex := range examples {
+		assert.Equal(t, ex.expected, IsSafeCapabilityValue(ex.val), "IsSafeCapabilityValue(%q)", ex.val)
 	}
 }

--- a/internal/pktline/capabilities_test.go
+++ b/internal/pktline/capabilities_test.go
@@ -73,3 +73,26 @@ func TestParseCapabilitiesWithArguments(t *testing.T) {
 		)
 	}
 }
+
+func TestSafeCapabilityValue(t *testing.T) {
+	good := []string{
+		"",
+		"AA:BB:CC:01",
+		"abcdefg",
+	}
+
+	for _, s := range good {
+		assert.True(t, IsSafeCapabilityValue(s), "%q should be ok", s)
+	}
+
+	bad := []string{
+		"not valid",
+		"not\tvalid",
+		"not\rvalid",
+		"not\nvalid",
+	}
+
+	for _, s := range bad {
+		assert.False(t, IsSafeCapabilityValue(s), "%q should not be ok", s)
+	}
+}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -81,7 +81,7 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 	}
 
 	capabilitiesLine := supportedCapabilities + fmt.Sprintf(" agent=github/spokes-receive-pack-%s", version)
-	if requestID := os.Getenv("GIT_SOCKSTAT_VAR_request_id"); requestID != "" {
+	if requestID := os.Getenv("GIT_SOCKSTAT_VAR_request_id"); requestID != "" && pktline.IsSafeCapabilityValue(requestID) {
 		capabilitiesLine += " session-id=" + requestID
 	}
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	capabilities = "report-status report-status-v2 delete-refs side-band-64k ofs-delta atomic push-options object-format=sha1 quiet"
+	supportedCapabilities = "report-status report-status-v2 delete-refs side-band-64k ofs-delta atomic push-options object-format=sha1 quiet"
+
 	// maximum length of a pkt-line's data component
 	maxPacketDataLength = 65516
 	nullSHA1OID         = "0000000000000000000000000000000000000000"
@@ -79,11 +80,16 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		return 1, err
 	}
 
+	capabilitiesLine := supportedCapabilities + fmt.Sprintf(" agent=github/spokes-receive-pack-%s", version)
+	if requestID := os.Getenv("GIT_SOCKSTAT_VAR_request_id"); requestID != "" {
+		capabilitiesLine += " session-id=" + requestID
+	}
+
 	rp := &spokesReceivePack{
 		input:            stdin,
 		output:           stdout,
 		err:              stderr,
-		capabilities:     capabilities + fmt.Sprintf(" agent=github/spokes-receive-pack-%s", version),
+		capabilities:     capabilitiesLine,
 		repoPath:         repoPath,
 		config:           config,
 		statelessRPC:     *statelessRPC,


### PR DESCRIPTION
I was testing `git push` recently and wanted to correlate my pushes with logs. It's easiest to do this when I can get my push's request ID from `git push`. When using HTTP to push, I can `GIT_CURL_VERBOSE=1 git push` and find the request ID in the HTTP response. But when I use ssh to push, the request ID isn't provided to the client, so I have to snoop around and pick my push out of the logs to find the request ID.

This branch adds the current request ID as `session-id` to the capabilities that spokes-receive-pack advertises in order to help with debugging.