### PR TITLE
Send gitmon schedule response to gitrpcd 

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -188,6 +189,8 @@ func readSockstat(environ []string) updateData {
 			res.PubkeyVerifierID = sockstat.Uint32Value(parts[1])
 		case "pubkey_creator_id":
 			res.PubkeyCreatorID = sockstat.Uint32Value(parts[1])
+		case "gitmon_delay":
+			res.GitmonDelay = sockstat.Uint32Value(parts[1])
 		}
 	}
 

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -69,6 +69,7 @@ type updateData struct {
 	GitProtocol      string `json:"git_protocol,omitempty"`
 	PubkeyVerifierID uint32 `json:"pubkey_verifier_id,omitempty"`
 	PubkeyCreatorID  uint32 `json:"pubkey_creator_id,omitempty"`
+	GitmonDelay      uint32 `json:"gitmon_delay,omitempty"`
 }
 
 func update(w io.Writer, ud updateData) error {

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -119,7 +119,7 @@ func (err FailError) Error() string {
 	return fmt.Sprintf("governor refuses to schedule us: %s", err.Reason)
 }
 
-func schedule(r *bufio.Reader, w io.Writer) error {
+func schedule(r *bufio.Reader, w io.Writer, sideband io.Writer) error {
 	const msg = `{"command":"schedule"}`
 
 	_, err := w.Write([]byte(msg))
@@ -133,6 +133,11 @@ func schedule(r *bufio.Reader, w io.Writer) error {
 	}
 
 	line := string(b[:len(b)-1])
+
+	//Forward message to gitrpcd
+	if sideband != nil {
+		sideband.Write(b)
+	}
 
 	words := strings.SplitN(line, " ", 3)
 	switch words[0] {

--- a/internal/governor/governor_test.go
+++ b/internal/governor/governor_test.go
@@ -60,7 +60,7 @@ func TestSchedule(t *testing.T) {
 			var toGov bytes.Buffer
 			fromGov := bufio.NewReader(strings.NewReader(ex.response))
 
-			err := schedule(fromGov, &toGov)
+			err := schedule(fromGov, &toGov, nil)
 
 			assert.Equal(t, ex.expectedError, err)
 			assert.Equal(t, `{"command":"schedule"}`, toGov.String())


### PR DESCRIPTION
In order to send a 429 responses to git clients on pushes `spokes-receive-pack` also need to send the response of gitmon schedule to gitrpcd.

We open the sideband file descriptor sent to `spokes-receive-pack` by `gitrpcd` as the `GITMON_SIDEBAND_FD` environment variable. And forward `gitmon` schedule responses to `gitrpcd` using that sideband.