### PR TITLE
Trim the ui:int bits of the GIT_SOCKSTAT_VAR_parent_repo_id before we use it

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -367,7 +367,7 @@ func (r *spokesReceivePack) performReferenceDiscovery(ctx context.Context) error
 	}
 
 	// Collect the reference tips present in the parent repo in case this is a fork
-	parentRepoId := os.Getenv("GIT_SOCKSTAT_VAR_parent_repo_id")
+	parentRepoId := strings.TrimPrefix(os.Getenv("GIT_SOCKSTAT_VAR_parent_repo_id"), "uint:")
 	advertiseTags := os.Getenv("GIT_NW_ADVERTISE_TAGS")
 
 	if parentRepoId != "" {


### PR DESCRIPTION
` .have's` advertisement seems not to be working as expected and we're seeing some objects transfers that shouldn't be required.

It could be that we are not properly dealing with the actual value of `GIT_SOCKSTAT_VAR_parent_repo_id `. The previous version of the program used to compute the network tips included the trimming of the actual value, so let's include it here, just to be safe