### PR TITLE
Make the quarantine with 0777 (before umask)

### DIFF
--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -856,7 +856,7 @@ func (r *spokesReceivePack) makeQuarantineDirs() error {
 			failpoint.Return(errors.New("error creating quarantine dirs"))
 		}
 	})
-	return os.MkdirAll(filepath.Join(r.quarantineFolder, "pack"), 0700)
+	return os.MkdirAll(filepath.Join(r.quarantineFolder, "pack"), 0777)
 }
 
 // performCheckConnectivity checks that the "new" oid provided in `commands` are


### PR DESCRIPTION
Quarantine directories are getting created with 0700 permissions, when the rest of the objects dirs are 0755. This makes the quarantine inaccessible to anyone other than the `git` service account (including the `gitro` account and custom pre-receive hooks on GHES).

This matches what Git does ([example](https://github.com/git/git/blob/186b115d3062e6230ee296d1ddaa0c4b72a464b5/object-file.c#L319), I'm not sure if this is the best example, but there are lots of examples of `mkdir(path, 0777)`).

cc @migue @terrorobe @ttaylorr @vdye (note that this is a public repo)