### PR TITLE
Handle gitmon protocol version

### DIFF
--- a/internal/governor/governor_test.go
+++ b/internal/governor/governor_test.go
@@ -31,7 +31,15 @@ func TestSchedule(t *testing.T) {
 		},
 		{
 			response:      "wait 100\n",
-			expectedError: WaitError{Duration: 100 * time.Second},
+			expectedError: WaitError{Duration: 100 * time.Second, Reason: "UNKNOWN"},
+		},
+		{
+			response:      "wait 100 network:ip\n",
+			expectedError: WaitError{Duration: 100 * time.Second, Reason: "network:ip"},
+		},
+		{
+			response:      "wait 100 network:reason with spaces\n",
+			expectedError: WaitError{Duration: 100 * time.Second, Reason: "network:reason with spaces"},
 		},
 		{
 			response:      "fail Too Busy\n",


### PR DESCRIPTION
We needed [to adjust the gitmon protocol](https://github.com/github/gitmon/pull/665) to return the reason of a throttle or failure to gitmon clients as part of implementing [babeld 429](https://github.com/github/babeld/issues/1494).

The gitmon message format changed to `wait <delay> <reasons>\n` and `fail <delay> <reasons>\n`.

This PR changes the way the gitmon protocol message is currently parsed, and extract the throttling and failure reasons from it.