### PR TITLE
Forward more fields to gitmon

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -178,6 +178,8 @@ func readSockstat(environ []string) updateData {
 			res.PubkeyCreatorID = sockstat.Uint32Value(parts[1])
 		case "gitmon_delay":
 			res.GitmonDelay = sockstat.Uint32Value(parts[1])
+		case "command_id":
+			res.CommandID = sockstat.StringValue(parts[1])
 		}
 	}
 

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -176,6 +176,8 @@ func readSockstat(environ []string) updateData {
 			res.PubkeyVerifierID = sockstat.Uint32Value(parts[1])
 		case "pubkey_creator_id":
 			res.PubkeyCreatorID = sockstat.Uint32Value(parts[1])
+		case "gitmon_delay":
+			res.GitmonDelay = sockstat.Uint32Value(parts[1])
 		}
 	}
 

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -69,6 +69,7 @@ type updateData struct {
 	GitProtocol      string `json:"git_protocol,omitempty"`
 	PubkeyVerifierID uint32 `json:"pubkey_verifier_id,omitempty"`
 	PubkeyCreatorID  uint32 `json:"pubkey_creator_id,omitempty"`
+	GitmonDelay      uint32 `json:"gitmon_delay,omitempty"`
 }
 
 func update(w io.Writer, ud updateData) error {

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -70,6 +70,10 @@ type updateData struct {
 	PubkeyVerifierID uint32 `json:"pubkey_verifier_id,omitempty"`
 	PubkeyCreatorID  uint32 `json:"pubkey_creator_id,omitempty"`
 	GitmonDelay      uint32 `json:"gitmon_delay,omitempty"`
+	// An ID that identifies a group of commands that all make up one
+	// logical request. Is only used by the githttpdaemon to sync
+	// its gitmon proxy and request scheduler logical threads
+	CommandID string `json:"command_id,omitempty"`
 }
 
 func update(w io.Writer, ud updateData) error {


### PR DESCRIPTION
We need to forward the `command_id` and `gitmon_delay` field to gitmon.

The `command_id` field is used to identify processes that make up
a logical request. It is used by the githttpdaemon to synchronise its
gitmon proxy and request scheduler logical threads.

The `gitmon_delay` is used by gitmon to determine how long we want to wait
until we reject a client request.