### PR TITLE
Support for SHA-256 repositories

### DIFF
--- a/internal/objectformat/git.go
+++ b/internal/objectformat/git.go
@@ -1,0 +1,46 @@
+package objectformat
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	NullOIDSHA1   = "0000000000000000000000000000000000000000"
+	NullOIDSHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+type ObjectFormat string
+
+// GetObjectFormat returns the object format for the repo located at repo.
+func GetObjectFormat(repo string) (ObjectFormat, error) {
+	cmd := exec.Command(
+		"git",
+		"rev-parse",
+		"--show-object-format",
+	)
+	cmd.Dir = repo
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("reading git object format: %w", err)
+	}
+
+	value := strings.TrimSpace(string(out))
+	switch value {
+	case "sha1", "sha256":
+		return ObjectFormat(value), nil
+	default:
+		return "", fmt.Errorf("unknown object format: %s", value)
+	}
+}
+
+func (of ObjectFormat) NullOID() string {
+	switch of {
+	case "sha256":
+		return NullOIDSHA256
+	default:
+		return NullOIDSHA1
+	}
+}

--- a/internal/objectformat/git_test.go
+++ b/internal/objectformat/git_test.go
@@ -1,0 +1,26 @@
+package objectformat
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullOID(t *testing.T) {
+	nullRE := regexp.MustCompile(`\A0+\z`)
+
+	sha1 := ObjectFormat("sha1")
+	require.Equal(t, len(sha1.NullOID()), 40)
+	require.Regexp(t, nullRE, sha1.NullOID())
+
+	sha256 := ObjectFormat("sha256")
+	require.Equal(t, len(sha256.NullOID()), 64)
+	require.Regexp(t, nullRE, sha256.NullOID())
+}
+
+func TestGetObjectFormat(t *testing.T) {
+	of, err := GetObjectFormat("../spokes/testdata/lots-of-refs.git")
+	require.NoError(t, err)
+	require.Equal(t, of, ObjectFormat("sha1"))
+}

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/github/go-pipe/pipe"
 	"github.com/github/spokes-receive-pack/internal/config"
 	"github.com/github/spokes-receive-pack/internal/governor"
+	"github.com/github/spokes-receive-pack/internal/objectformat"
 	"github.com/github/spokes-receive-pack/internal/pktline"
 	"github.com/github/spokes-receive-pack/internal/sockstat"
 	"github.com/pingcap/failpoint"
@@ -33,8 +34,8 @@ const (
 
 	// maximum length of a pkt-line's data component
 	maxPacketDataLength = 65516
-	nullSHA1OID         = "0000000000000000000000000000000000000000"
-	nullSHA256OID       = "000000000000000000000000000000000000000000000000000000000000"
+	nullSHA1OID         = objectformat.NullOIDSHA1
+	nullSHA256OID       = objectformat.NullOIDSHA256
 )
 
 // Exec is similar to a main func for the new version of receive-pack.


### PR DESCRIPTION
We have some preliminary support for SHA-256 repositories here, but it's incomplete.  Notably, the capabilities line doesn't use the correct all-zero (null) OID, and the null OID we have for SHA-256 is actually too short.

There are a couple commits here which allow us to read the object format from the repository and choose the correct values, and we also emit the correct null object ID in both cases.  With this change, the relevant gitrpcd tests pass in the `sha256` branch.

This PR contains independent, logical, bisectable commits each with their own commit message, and as such is best reviewed commit by commit.
