### PR TITLE
Allow for custom scheduler timeout

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -57,7 +57,7 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 	failClosed := shouldFailClosed()
 	br := bufio.NewReader(sock)
 	for {
-		// Give governor 1s to respond each schedule call.
+		// Give governor a limited time to respond.
 		if err := sock.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 			break
 		}

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,9 +13,23 @@ import (
 )
 
 const (
-	connectTimeout  = time.Second
-	scheduleTimeout = time.Second
+	connectTimeout = time.Second
 )
+
+func scheduleTimeout() time.Duration {
+	timeout := time.Second
+	if v := os.Getenv("SCHEDULE_CMD_TIMEOUT"); v != "" {
+		if d, err := strconv.ParseInt(v, 10, 64); err == nil {
+			timeout = time.Duration(d) * time.Millisecond
+		}
+	}
+
+	return timeout
+}
+
+func shouldFailClosed() bool {
+	return os.Getenv("FAIL_CLOSED") == "1"
+}
 
 // Start connects to governor and sends the "update" and "schedule" messages.
 //
@@ -38,10 +53,12 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 		return nil, nil
 	}
 
+	timeout := scheduleTimeout()
+	failClosed := shouldFailClosed()
 	br := bufio.NewReader(sock)
 	for {
 		// Give governor 1s to respond each schedule call.
-		if err := sock.SetReadDeadline(time.Now().Add(scheduleTimeout)); err != nil {
+		if err := sock.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 			break
 		}
 
@@ -56,6 +73,14 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 		case FailError:
 			sock.Close()
 			return nil, err
+		case net.Error:
+			sock.Close()
+
+			if e.Timeout() && failClosed {
+				return nil, err
+			}
+
+			return nil, nil
 		default:
 			sock.Close()
 			return nil, nil

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -270,7 +270,7 @@ func (suite *SpokesReceivePackTestSuite) TestSucceedsWithCustomGovernorTimeoutAn
 	cmd.Env = append(cmd.Env, "SCHEDULE_CMD_TIMEOUT=100")
 	out, err := cmd.CombinedOutput()
 	suite.T().Logf("git push output:\n%s", out)
-	assert.NoError(suite.T(), err, "Should fail not fail due to timeout")
+	assert.NoError(suite.T(), err, "Should not fail due to timeout")
 }
 
 func startFakeGovernor(t *testing.T, started chan any, onConnAccepted func()) (string, <-chan govMessage, func()) {


### PR DESCRIPTION
The caller should be able to set a custom timeout, and fail closed on demand.

This change adds a `SCHEDULE_CMD_TIMEOUT` env variable that can be set by the caller. It also adds a `FAIL_CLOSED` env variable that will abort the spokes-receive-pack process execution when a timeout was reached, instead of allowing to run as it was previously the case.