### PR TITLE
internal/spokes: handle suffixed `receive.maxSize`, etc. configuration values

### DIFF
--- a/internal/config/git.go
+++ b/internal/config/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -100,5 +101,33 @@ func (c *Config) GetPrefix(prefix string) map[string][]string {
 			m[trimmedKey] = append(m[trimmedKey], entry.Value)
 		}
 	}
-	return m 
+	return m
+}
+
+// ParseSigned parses a string that may contain a signed integer with an
+// optional suffix (either 'k', 'm', or 'g' for their respective IEC values).
+func ParseSigned(str string) (int, error) {
+	factor := 1
+
+	if len(str) > 0 {
+		switch str[len(str)-1] {
+		case 'k', 'K':
+			factor = 1024
+		case 'm', 'M':
+			factor = 1024 * 1024
+		case 'g', 'G':
+			factor = 1024 * 1024 * 1024
+		}
+
+		if factor != 1 {
+			str = str[:len(str)-1]
+		}
+	}
+
+	n, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, err
+	}
+
+	return n * factor, nil
 }

--- a/internal/config/git_test.go
+++ b/internal/config/git_test.go
@@ -115,3 +115,45 @@ func commandBuilderInDir(dir string) func(string, ...string) *exec.Cmd {
 		return c
 	}
 }
+
+func TestParseSigned(t *testing.T) {
+	for _, c := range []struct {
+		str     string
+		want    int
+		wantErr string
+	}{
+		// valid input, no suffix
+		{"81", 81, ""},
+
+		// valid input, with lower- and upper-case suffixes
+		{"2k", 2 * 1024, ""},
+		{"3m", 3 * 1024 * 1024, ""},
+		{"4g", 4 * 1024 * 1024 * 1024, ""},
+		{"2K", 2 * 1024, ""},
+		{"3M", 3 * 1024 * 1024, ""},
+		{"4G", 4 * 1024 * 1024 * 1024, ""},
+
+		// valid negative input, with lower- and upper-case suffixes
+		{"-2k", -2 * 1024, ""},
+		{"-3m", -3 * 1024 * 1024, ""},
+		{"-4g", -4 * 1024 * 1024 * 1024, ""},
+		{"-2K", -2 * 1024, ""},
+		{"-3M", -3 * 1024 * 1024, ""},
+		{"-4G", -4 * 1024 * 1024 * 1024, ""},
+
+		// empty input, just a suffix
+		{"k", 0, "strconv.Atoi: parsing \"\": invalid syntax"},
+		{"m", 0, "strconv.Atoi: parsing \"\": invalid syntax"},
+		{"g", 0, "strconv.Atoi: parsing \"\": invalid syntax"},
+
+		// invalid input, no suffix
+		{"NaN", 0, "strconv.Atoi: parsing \"NaN\": invalid syntax"},
+	} {
+		got, gotErr := ParseSigned(c.str)
+
+		assert.Equal(t, c.want, got)
+		if c.wantErr != "" {
+			assert.EqualError(t, gotErr, c.wantErr)
+		}
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -357,6 +357,18 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackMultiplePushWithEx
 		"unexpected error running the push with the custom spokes-receive-pack program")
 }
 
+func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackWithSuffixedReceiveMaxSize() {
+	assert.NoError(suite.T(), chdir(suite.T(), suite.remoteRepo), "unable to chdir into our remote Git repo")
+	require.NoError(suite.T(), exec.Command("git", "config", "receive.maxsize", "2G").Run())
+
+	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
+	assert.NoError(
+		suite.T(),
+		exec.Command(
+			"git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r").Run(),
+		"unexpected error running the push with the custom spokes-receive-pack program")
+}
+
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackMultiplePushFailMaxSize() {
 	assert.NoError(suite.T(), chdir(suite.T(), suite.remoteRepo), "unable to chdir into our remote Git repo")
 	// Set a really low value to receive.maxsize in order to make it fail

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -954,7 +953,7 @@ func (r *spokesReceivePack) getMaxInputSize() (int, error) {
 	maxSize := r.config.Get("receive.maxsize")
 
 	if maxSize != "" {
-		return strconv.Atoi(maxSize)
+		return config.ParseSigned(maxSize)
 	}
 
 	return 0, nil
@@ -964,7 +963,7 @@ func (r *spokesReceivePack) getWarnObjectSize() (int, error) {
 	warnObjectSize := r.config.Get("receive.warnobjectsize")
 
 	if warnObjectSize != "" {
-		return strconv.Atoi(warnObjectSize)
+		return config.ParseSigned(warnObjectSize)
 	}
 
 	return 0, nil
@@ -974,7 +973,7 @@ func (r *spokesReceivePack) getRefUpdateCommandLimit() (int, error) {
 	refUpdateCommandLimit := r.config.Get("receive.refupdatecommandlimit")
 
 	if refUpdateCommandLimit != "" {
-		return strconv.Atoi(refUpdateCommandLimit)
+		return config.ParseSigned(refUpdateCommandLimit)
 	}
 
 	return 0, nil
@@ -984,7 +983,7 @@ func (r *spokesReceivePack) getPushOptionsCountLimit() (int, error) {
 	limit := r.config.Get("receive.pushoptionscountlimit")
 
 	if limit != "" {
-		return strconv.Atoi(limit)
+		return config.ParseSigned(limit)
 	}
 
 	return 0, nil


### PR DESCRIPTION
This pull request teaches `spokes-receive-pack` to correctly process values like `2G` when handling the `receive.maxSize` configuration.

The first patch introduces a new function, `internal/config.ParseSigned()` which can parse strings like `2G` into their integer equivalents. This function is used in the second patch to correctly handle the `receive.maxSize` configuration value when assembling the command-line arguments for `git index-pack`.

The second patch also includes an integration test to ensure that we correctly handle suffixed values like `2G` and prevent regressions in this area in the future. Thanks in advance for your review!

##

/cc @github/git-platform