### PR TITLE
internal/spokes: set higher incoming push limit when migrating

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -341,11 +341,20 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackMultiplePushWithEx
 	require.NoError(suite.T(), exec.Command("git", "config", "receive.reportStatusFF", "true").Run())
 
 	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
-	assert.NoError(
-		suite.T(),
-		exec.Command(
-			"git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r").Run(),
-		"unexpected error running the push with the custom spokes-receive-pack program")
+	push := func() {
+		assert.NoError(
+			suite.T(),
+			exec.Command(
+				"git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r").Run(),
+			"unexpected error running the push with the custom spokes-receive-pack program")
+	}
+	push()
+
+	suite.T().Setenv("GIT_SOCKSTAT_VAR_is_importing", "bool:true")
+	push()
+
+	suite.T().Setenv("GIT_SOCKSTAT_VAR_is_importing", "bool:false")
+	push()
 }
 
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackWithSuffixedReceiveMaxSize() {

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -950,8 +950,11 @@ func (r *spokesReceivePack) isFsckConfigEnabled() bool {
 }
 
 func (r *spokesReceivePack) getMaxInputSize() (int, error) {
-	maxSize := r.config.Get("receive.maxsize")
+	if sockstat.GetBool("is_importing") {
+		return 80 * 1024 * 1024 * 1024, nil /* 80 GB */
+	}
 
+	maxSize := r.config.Get("receive.maxsize")
 	if maxSize != "" {
 		return config.ParseSigned(maxSize)
 	}


### PR DESCRIPTION
For repositories that are being migrated into GitHub, let's set a higher push limit than our standard 2 GB so that the tool performing that migration does not have to split up the repository into multiple pushes.

Note that the limit is not infinite here, since we have a hard cap for the size of an on-disk repository at 100 GB. Setting the limit to 80 GB ensures that the repository has sufficient room to grow after being migrated into GitHub.

##

/cc @bk2204, @spraints, @mhagger 
/cc @github/git-platform