### PR TITLE
workflow: set restricted permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,8 @@
 name: go test
 
+permissions:
+  contents: read
+
 on:
   push:
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,8 @@
 name: golangci-lint
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
If no explicit permissions are set for a GitHub Actions run, then the repository or organization permissions are used, which can be too broad. Let's specifically set the permissions to read-only for the contents of the repository, since we only need to clone and test our code. That way, we'll be taking advantage of the principle of least privilege.