### PR TITLE
Make the delay gitmon agnostic

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -201,8 +201,8 @@ func readSockstat(environ []string) updateData {
 			res.PubkeyVerifierID = sockstat.Uint32Value(parts[1])
 		case "pubkey_creator_id":
 			res.PubkeyCreatorID = sockstat.Uint32Value(parts[1])
-		case "gitmon_delay":
-			res.GitmonDelay = sockstat.Uint32Value(parts[1])
+		case "max_delay":
+			res.MaxDelay = sockstat.Uint32Value(parts[1])
 		case "command_id":
 			res.CommandID = sockstat.StringValue(parts[1])
 		}

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -69,7 +69,7 @@ type updateData struct {
 	GitProtocol      string `json:"git_protocol,omitempty"`
 	PubkeyVerifierID uint32 `json:"pubkey_verifier_id,omitempty"`
 	PubkeyCreatorID  uint32 `json:"pubkey_creator_id,omitempty"`
-	GitmonDelay      uint32 `json:"gitmon_delay,omitempty"`
+	MaxDelay         uint32 `json:"max_delay,omitempty"`
 	// An ID that identifies a group of commands that all make up one
 	// logical request. Is only used by the githttpdaemon to sync
 	// its gitmon proxy and request scheduler logical threads


### PR DESCRIPTION
This delay should not be tied to gitmon. This PR takes care of it.