### PR TITLE
Extract the process group data

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -205,6 +205,10 @@ func readSockstat(environ []string) updateData {
 			res.GitmonDelay = sockstat.Uint32Value(parts[1])
 		case "command_id":
 			res.CommandID = sockstat.StringValue(parts[1])
+		case "group_id":
+			res.GroupID = sockstat.StringValue(parts[1])
+		case "group_leader":
+			res.GroupLeader = sockstat.GetBool(parts[1])
 		}
 	}
 


### PR DESCRIPTION
The process group leader and id are used to throttle a group of processes. This change will allow `spokes-receive-pack` to be part of a process group, and be handled accordingly.