### PR TITLE
Split the is_importing stat in two

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -211,6 +211,10 @@ func readSockstat(environ []string) updateData {
 			res.GroupLeader = sockstat.GetBool(parts[1])
 		case "is_importing":
 			res.IsImporting = sockstat.BoolValue(parts[1])
+		case "import_skip_push_limit":
+			res.ImportSkipPushLimit = sockstat.BoolValue(parts[1])
+		case "import_soft_throttling":
+			res.ImportSoftThrottling = sockstat.BoolValue(parts[1])
 		}
 	}
 

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -76,6 +76,12 @@ type updateData struct {
 	CommandID string `json:"command_id,omitempty"`
 	// IsImporting is true if the command is an import.
 	IsImporting bool `json:"is_importing,omitempty"`
+	// ImportSkipPushLimit is true if the command is an import and
+	// we want to skip the push limit for a command.
+	ImportSkipPushLimit bool `json:"import_skip_push_limit,omitempty"`
+	// ImportSoftThrottling is true if the command is an import and
+	// we want to apply it some soft throttling policies.
+	ImportSoftThrottling bool `json:"import_soft_throttling,omitempty"`
 }
 
 func update(w io.Writer, ud updateData) error {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -225,7 +225,7 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackAllowedWhenWithIsI
 	assert.NoError(
 		suite.T(),
 		err,
-		"unexpected failure with the custome spokes-receive-pack program; it should have succeeded")
+		"unexpected failure with the custom spokes-receive-pack program; it should have succeeded")
 }
 
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackAllowedWhenWithImportSkipPushLimitSockStat() {
@@ -242,7 +242,7 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackAllowedWhenWithImp
 	assert.NoError(
 		suite.T(),
 		err,
-		"unexpected failure with the custome spokes-receive-pack program; it should have succeeded")
+		"unexpected failure with the custom spokes-receive-pack program; it should have succeeded")
 }
 
 func (suite *SpokesReceivePackTestSuite) TestWithGovernor() {

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -955,7 +955,11 @@ func (r *spokesReceivePack) isFsckConfigEnabled() bool {
 }
 
 func (r *spokesReceivePack) getMaxInputSize() (int, error) {
-	if isImporting() {
+	// We want to skip the default push limit when the `import_skip_push_limit`
+	// stat is set only.
+	// We keep using the `is_import` here for backward compatibility only,
+	// which should be removed on a subsequent PR.
+	if isImporting() || skipPushLimit() {
 		return 80 * 1024 * 1024 * 1024, nil /* 80 GB */
 	}
 
@@ -1232,6 +1236,10 @@ func isQuiet(c pktline.Capabilities) bool {
 
 func isImporting() bool {
 	return sockstat.GetBool("is_importing")
+}
+
+func skipPushLimit() bool {
+	return sockstat.GetBool("import_skip_push_limit")
 }
 
 func allowBadDate() bool {


### PR DESCRIPTION
We want to use two new different sockstats, `import_skip_push_limit` and `import_soft_throttling` which are respectively used to allow a higher push limit, and implement soft throttling policy for imports.

We still forward the `is_importing` stat for to skip push limit for backward compatibility. We plan to remove it on a subsequent PR.