### PR TITLE
Adjust importer's push limits

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -236,7 +236,25 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackAllowedWhenWithImp
 	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
 	cmd := exec.Command("git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r")
 	cmd.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_is_importing=bool:true",
 		"GIT_SOCKSTAT_VAR_import_skip_push_limit=bool:true",
+	)
+	err := cmd.Run()
+	assert.NoError(
+		suite.T(),
+		err,
+		"unexpected failure with the custom spokes-receive-pack program; it should have succeeded")
+}
+
+func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackAllowedWhenImporting() {
+	assert.NoError(suite.T(), chdir(suite.T(), suite.remoteRepo), "unable to chdir into our remote Git repo")
+	// Set a really low value to receive.maxsize in order to make it fail
+	require.NoError(suite.T(), exec.Command("git", "config", "receive.maxsize", "1").Run())
+
+	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
+	cmd := exec.Command("git", "push", "--all", "--receive-pack=spokes-receive-pack-wrapper", "r")
+	cmd.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_is_importing=bool:true",
 	)
 	err := cmd.Run()
 	assert.NoError(


### PR DESCRIPTION
Iterating on #84, we'd like the default limit for pushes by GEI to be 40 GiB, with an option to raise the limit to 80 GiB.

cc @iomekam @ttaylorr @mhagger @elhmn 
cc https://github.slack.com/archives/C12RL65A9/p1741290565885329 (no xref because this is a public repo!)