### PR TITLE
Modernize analyzer support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,15 @@ lint: | $(GOLANGCILINT)
 	@echo "$(M) running golangci-lint"
 	$(GOLANGCILINT) run
 
+# Run modernize on all source files:
+GOLANGMODERNIZE := $(BIN)/modernize
+$(BIN)/modernize:
+	GOBIN=$(BIN) $(GO) install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
+
+.PHONY: modernize
+modernize: | $(GOLANGMODERNIZE)
+	@echo "$(M) running golangci-lint"
+	$(GOLANGMODERNIZE) -fix -test ./...
 ###########################################################################
 
 # Cleanup


### PR DESCRIPTION
This tiny patch introduce modernizer: a package provided by the `x/tools/gopls` package that provides suggestions to simplify your code by using modern constructs

For example, if we run it in our project, we will get something like:

```
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:283:12: Redundant clone of os.Environ()
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:871:12: Redundant clone of os.Environ()
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:1094:12: Redundant clone of os.Environ()
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:1149:12: Redundant clone of os.Environ()
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:670:52: interface{} can be replaced by any
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:1208:6: if statement can be modernized using min
/Users/migue/development/sourcecode/github/spokes-receive-pack/internal/spokes/spokes.go:1263:6: for loop can be modernized using range over int
exit status 3
```

The current patch includes the `-fix`, performing the actual changes in the source code