### PR TITLE
Revert "Remove spokes_quarantine sockstat var"

### DIFF
--- a/cmd/spokes-receive-pack-networked-wrapper/main.go
+++ b/cmd/spokes-receive-pack-networked-wrapper/main.go
@@ -13,6 +13,7 @@ import (
 // binary during our networked integration tests
 func main() {
 	env := []string{
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=test_quarantine_id",
 		"GIT_SOCKSTAT_VAR_parent_repo_id=git-internals",
 		"GIT_NW_ADVERTISE_TAGS=true",

--- a/cmd/spokes-receive-pack-wrapper/main.go
+++ b/cmd/spokes-receive-pack-wrapper/main.go
@@ -13,6 +13,7 @@ import (
 // binary during our integration tests
 func main() {
 	env := []string{
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=test_quarantine_id",
 	}
 	if err := integration.RunMain(env); err != nil {

--- a/internal/config/git_test.go
+++ b/internal/config/git_test.go
@@ -97,7 +97,7 @@ func TestGetPrefixParsesArgs(t *testing.T) {
 	assert.NoError(t, cmd("git", "config", "user.name", "spokes-receive-pack").Run())
 	assert.NoError(t, cmd("git", "config", "receive.fsck.missingEmail", "ignore").Run())
 	assert.NoError(t, cmd("git", "config", "receive.fsck.badTagName", "ignore").Run())
-	assert.NoError(t, cmd("git", "config", "--add", "receive.fsck.badTagName", "error").Run())
+	assert.NoError(t, cmd("git", "config","--add", "receive.fsck.badTagName", "error").Run())
 
 	config, _ := GetConfig(localRepo)
 	prefix := config.GetPrefix("receive.fsck.")
@@ -106,6 +106,7 @@ func TestGetPrefixParsesArgs(t *testing.T) {
 	assert.Equal(t, prefix["badtagname"][0], "ignore")
 	assert.Equal(t, prefix["badtagname"][1], "error")
 }
+
 
 func commandBuilderInDir(dir string) func(string, ...string) *exec.Cmd {
 	return func(program string, args ...string) *exec.Cmd {

--- a/internal/integration/capabilities_test.go
+++ b/internal/integration/capabilities_test.go
@@ -60,6 +60,7 @@ func TestCapabilities(t *testing.T) {
 
 		srp.Env = append(os.Environ(),
 			"GIT_CONFIG_PARAMETERS="+configParams,
+			"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 			"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 		srp.Env = append(srp.Env, extraEnv...)
 		srp.Stderr = &testLogWriter{t}

--- a/internal/integration/hiderefs_test.go
+++ b/internal/integration/hiderefs_test.go
@@ -67,6 +67,7 @@ func TestHiderefsConfig(t *testing.T) {
 	srp.Dir = testRepo
 	srp.Env = append(os.Environ(),
 		"GIT_CONFIG_PARAMETERS="+gitConfigParameters,
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -100,6 +100,15 @@ func (suite *SpokesReceivePackTestSuite) TearDownTest() {
 	require.NoError(os.RemoveAll(suite.localRepo))
 }
 
+func (suite *SpokesReceivePackTestSuite) TestDefaultReceivePackSimplePush() {
+	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
+	assert.NoError(
+		suite.T(),
+		exec.Command(
+			"git", "push", "--receive-pack=spokes-receive-pack", "r", "HEAD").Run(),
+		"unexpected error running the push with the default receive-pack implementation")
+}
+
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackSimplePush() {
 	assert.NoError(suite.T(), chdir(suite.T(), suite.localRepo), "unable to chdir into our local Git repo")
 	assert.NoError(
@@ -520,6 +529,7 @@ func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackWrongObjectSucceed
 			"unexpected error running the push with the custom spokes-receive-pack program; it should have succeed since fsck is disabled")
 	})
 }
+
 
 func (suite *SpokesReceivePackTestSuite) TestSpokesReceivePackIgnoreArgsSucceed() {
 	assert.NoError(suite.T(), chdir(suite.T(), suite.remoteRepo), "unable to chdir into our remote Git repo")

--- a/internal/integration/missingobjects_test.go
+++ b/internal/integration/missingobjects_test.go
@@ -146,6 +146,7 @@ func startSpokesReceivePack(ctx context.Context, t *testing.T, testRepo string) 
 	srp := exec.CommandContext(ctx, "spokes-receive-pack", ".")
 	srp.Dir = testRepo
 	srp.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
 		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()

--- a/internal/integration/nosideband_test.go
+++ b/internal/integration/nosideband_test.go
@@ -39,7 +39,9 @@ func TestNoSideBand(t *testing.T) {
 
 	srp := exec.CommandContext(ctx, "spokes-receive-pack", ".")
 	srp.Dir = testRepo
-	srp.Env = append(os.Environ(), "GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
+	srp.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
+		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)

--- a/internal/integration/pushoptions_test.go
+++ b/internal/integration/pushoptions_test.go
@@ -44,7 +44,9 @@ func TestPushOptions(t *testing.T) {
 
 	srp := exec.CommandContext(ctx, "spokes-receive-pack", ".")
 	srp.Dir = testRepo
-	srp.Env = append(os.Environ(), "GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
+	srp.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
+		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)
@@ -100,7 +102,9 @@ func TestPushOptionsLimitCount(t *testing.T) {
 
 	srp := exec.CommandContext(ctx, "spokes-receive-pack", ".")
 	srp.Dir = testRepo
-	srp.Env = append(os.Environ(), "GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
+	srp.Env = append(os.Environ(),
+		"GIT_SOCKSTAT_VAR_spokes_quarantine=bool:true",
+		"GIT_SOCKSTAT_VAR_quarantine_id=config-test-quarantine-id")
 	srp.Stderr = &testLogWriter{t}
 	srpIn, err := srp.StdinPipe()
 	require.NoError(t, err)

--- a/spokes-receive-pack.go
+++ b/spokes-receive-pack.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/github/spokes-receive-pack/internal/receivepack"
+	"github.com/github/spokes-receive-pack/internal/sockstat"
 	"github.com/github/spokes-receive-pack/internal/spokes"
 )
 
@@ -21,5 +23,14 @@ func main() {
 
 func mainImpl(stdin io.Reader, stdout, stderr io.Writer, args []string) (int, error) {
 	ctx := context.Background()
+	if !sockstat.GetBool("spokes_quarantine") {
+		rp := receivepack.NewReceivePack(stdin, stdout, stderr, args)
+		if err := rp.Execute(ctx); err != nil {
+			return 1, fmt.Errorf("unexpected error running receive pack: %w", err)
+		}
+
+		return 0, nil
+	}
+
 	return spokes.Exec(ctx, stdin, stdout, stderr, args, BuildVersion)
 }


### PR DESCRIPTION
Reverts github/spokes-receive-pack#80

A bunch of integration tests are failing, and after running a bisect turns out this changes seem to be the main cause of those failures.
This PR will initially be used to test whether or not this assumption is correct. Once it is confirmed, we 
can go ahead and revert them.

UPDATE: I was able to confirm that a significant amout of integration tests were fixed after this change was reverted, and would like to have this changes merged.

---

*Sorry for the relatively vague description, but since this repo is public, I can't provide much more context than that, ping me on slack if you need further informations.*