### PR TITLE
Update default socket path

### DIFF
--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -153,7 +153,7 @@ func connect(ctx context.Context) (net.Conn, error) {
 
 	path := os.Getenv("GIT_SOCKSTAT_PATH")
 	if path == "" {
-		path = "/var/run/gitmon/gitstats.sock"
+		path = "/run/governor/client.sock"
 	}
 
 	dialer := &net.Dialer{}


### PR DESCRIPTION
This change updates the `GIT_SOCKSTAT_PATH` value to `"/run/governor/client.sock"`.