### PR TITLE
Bump golang to 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - name: Install git.
         run: |
           sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Vendor modules for later steps.
         run: |
           go mod vendor
-      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.64
+          version: v2.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/spokes-receive-pack
 
-go 1.24
+go 1.25
 
 require (
 	github.com/github/go-pipe v1.0.2

--- a/internal/config/git_test.go
+++ b/internal/config/git_test.go
@@ -19,7 +19,7 @@ func testGetConfigEntryValue(repoPath, name string) string {
 
 func TestGetConfigMultipleValues(t *testing.T) {
 	localRepo, err := os.MkdirTemp("", "repo")
-	defer os.RemoveAll(localRepo)
+	defer func() { _ = os.RemoveAll(localRepo) }()
 
 	assert.NoError(t, err, fmt.Sprintf("unable to create the local Git repo: %s", err))
 
@@ -45,7 +45,7 @@ func TestGetConfigMultipleValues(t *testing.T) {
 
 func TestGetConfigEntryValues(t *testing.T) {
 	localRepo, err := os.MkdirTemp("", "repo")
-	defer os.RemoveAll(localRepo)
+	defer func() { _ = os.RemoveAll(localRepo) }()
 
 	assert.NoError(t, err, fmt.Sprintf("unable to create the local Git repo: %s", err))
 
@@ -66,7 +66,7 @@ func TestGetConfigEntryValues(t *testing.T) {
 
 func TestGetConfigEntryMultipleValues(t *testing.T) {
 	localRepo, err := os.MkdirTemp("", "repo")
-	defer os.RemoveAll(localRepo)
+	defer func() { _ = os.RemoveAll(localRepo) }()
 
 	assert.NoError(t, err, fmt.Sprintf("unable to create the local Git repo: %s", err))
 
@@ -85,7 +85,7 @@ func TestGetConfigEntryMultipleValues(t *testing.T) {
 }
 func TestGetPrefixParsesArgs(t *testing.T) {
 	localRepo, err := os.MkdirTemp("", "repo")
-	defer os.RemoveAll(localRepo)
+	defer func() { _ = os.RemoveAll(localRepo) }()
 
 	assert.NoError(t, err, fmt.Sprintf("unable to create the local Git repo: %s", err))
 

--- a/internal/governor/conn.go
+++ b/internal/governor/conn.go
@@ -49,7 +49,7 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 	updateData.Program = "spokes-receive-pack"
 	updateData.GitDir = gitDir
 	if err := update(sock, updateData); err != nil {
-		sock.Close()
+		_ = sock.Close()
 		return nil, nil
 	}
 
@@ -71,10 +71,10 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 		case WaitError:
 			time.Sleep(e.Duration)
 		case FailError:
-			sock.Close()
+			_ = sock.Close()
 			return nil, err
 		case net.Error:
-			sock.Close()
+			_ = sock.Close()
 
 			if e.Timeout() && failClosed {
 				return nil, err
@@ -82,7 +82,7 @@ func Start(ctx context.Context, gitDir string) (*Conn, error) {
 
 			return nil, nil
 		default:
-			sock.Close()
+			_ = sock.Close()
 			return nil, nil
 		}
 	}
@@ -136,7 +136,7 @@ func (c *Conn) Finish(ctx context.Context) {
 
 	_ = finish(c.sock, c.finish)
 
-	c.sock.Close()
+	_ = c.sock.Close()
 	c.sock = nil
 }
 

--- a/internal/spokes/spokes.go
+++ b/internal/spokes/spokes.go
@@ -46,7 +46,7 @@ func Exec(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writ
 	flag.Parse()
 
 	if flag.NArg() != 1 {
-		return 1, fmt.Errorf("Unexpected number of keyword args (%d). Expected repository name, got %s ", flag.NArg(), flag.Args())
+		return 1, fmt.Errorf("Unexpected number of keyword args (%d). Expected repository name, got %v", flag.NArg(), flag.Args()) //nolint:staticcheck // user-facing error message
 	}
 
 	// Assume that this is a bare repository. chdir to it and take the full
@@ -137,7 +137,7 @@ func (r *spokesReceivePack) RemoveQuarantine() {
 	// Let's make sure we don't leave any quarantine files behind if something goes wrong
 	// If the error has happened before we have created the quarantine dir, we don't need to remove it, but RemoveAll won't fail
 	// If the error has happened after we have created the quarantine dir, the folder will be removed
-	os.RemoveAll(r.quarantineFolder)
+	_ = os.RemoveAll(r.quarantineFolder)
 }
 
 // execute executes our custom implementation
@@ -889,7 +889,7 @@ func (r *spokesReceivePack) readPack(ctx context.Context, commands []command, ca
 	indexPackOut := make(chan []byte, 1)
 	go func(r io.ReadCloser, res chan<- []byte) {
 		defer close(indexPackOut)
-		defer r.Close()
+		defer func() { _ = r.Close() }()
 		out, _ := io.ReadAll(r)
 		indexPackOut <- out
 	}(stdout, indexPackOut)
@@ -1259,7 +1259,7 @@ func sideBandBufSize(capabilities pktline.Capabilities) int {
 func isHex(s string) bool {
 	for i := range len(s) {
 		c := s[i]
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) { //nolint:staticcheck // clearer as-is
 			return false
 		}
 	}


### PR DESCRIPTION
I just want to take smaller steps 1.26 enables Green Tea Garbage Collector by default. So maybe it's better to update to 1.25 first and not skip a major version.